### PR TITLE
fix 2 bugs

### DIFF
--- a/server/op_editconfig.c
+++ b/server/op_editconfig.c
@@ -126,7 +126,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
     enum NP2_EDIT_ERROPT erropt = NP2_EDIT_ERROPT_STOP;
     struct lyxml_elem *config_xml;
     struct lyd_node *config = NULL, *next, *iter;
-    char *str, path[1024], *rel;
+    char *str, path[1024], *rel, *valbuf;
     const char *cstr;
     enum NP2_EDIT_OP *op = NULL, *op_new;
     int op_index, op_size, path_index = 0, missing_keys = 0, lastkey = 0;
@@ -336,7 +336,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
 
             if (op[op_index] < NP2_EDIT_DELETE) {
                 /* set value for sysrepo, it will be used as soon as all the keys are processed */
-                op_set_srval(iter, NULL, 0, &value, &str);
+                op_set_srval(iter, NULL, 0, &value, &valbuf);
             }
 
             /* the creation must be finished later when we get know keys */
@@ -352,7 +352,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
 
         if (op[op_index] < NP2_EDIT_DELETE && !lastkey) {
             /* set value for sysrepo */
-            op_set_srval(iter, NULL, 0, &value, &str);
+            op_set_srval(iter, NULL, 0, &value, &valbuf);
         }
 
         /* apply change to sysrepo */
@@ -378,9 +378,9 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
             /* do nothing */
             break;
         }
-        if (str) {
-            free(str);
-            str = NULL;
+        if (valbuf) {
+            free(valbuf);
+            valbuf = NULL;
         }
 
 resultcheck:
@@ -543,7 +543,7 @@ cleanup:
                         }
                         e = NULL;
                     }
-                    goto errorreply;
+                    goto internalerror;
                 default:
                     goto internalerror;
                 }


### PR DESCRIPTION
1. session not refreshed when sysrepo commit return SR_ERR_VALIDATION_FAILED. 
you can test with leaflist and config elements more than it's max-element in edit-config

2. free str would crush system in line 382 because str pointed to path in line 472 or 496