### PR TITLE
cmake: Allow specifying several libs in sysrepo.pc

### DIFF
--- a/CMakeModules/FindSYSREPO.cmake
+++ b/CMakeModules/FindSYSREPO.cmake
@@ -4,23 +4,25 @@
 #  SYSREPO_DEFINITIONS - Compiler switches required for using SYSREPO
 
 find_package(PkgConfig)
-pkg_check_modules(PC_SYSREPO QUIET sysrepo)
-set(SYSREPO_DEFINITIONS ${PC_SYSREPO_CFLAGS_OTHER})
-
-find_path(SYSREPO_INCLUDE_DIR sysrepo.h
-          HINTS ${PC_SYSREPO_INCLUDEDIR} ${PC_SYSREPO_INCLUDE_DIRS}
-          PATH_SUFFIXES sysrepo )
-
-find_library(SYSREPO_LIBRARY NAMES sysrepo 
-             HINTS ${PC_SYSREPO_LIBDIR} ${PC_SYSREPO_LIBRARY_DIRS} )
-
-set(SYSREPO_LIBRARIES ${SYSREPO_LIBRARY} )
-set(SYSREPO_INCLUDE_DIRS ${SYSREPO_INCLUDE_DIR} )
+if (SYSREPO_FIND_REQUIRED)
+    set(find_sysrepo_options REQUIRED)
+elseif (SYSREPO_FIND_QUIETLY)
+    set(find_sysrepo_options QUIET)
+else()
+    set(find_sysrepo_options)
+endif()
+mark_as_advanced(find_sysrepo_options)
+pkg_check_modules(PC_SYSREPO libsysrepo ${find_sysrepo_options})
+set(SYSREPO_INCLUDE_DIRS "${PC_SYSREPO_INCLUDE_DIRS}")
+set(SYSREPO_DEFINITIONS "${PC_SYSREPO_DEFINITIONS}")
+foreach(sysrepo_lib ${PC_SYSREPO_LIBRARIES})
+    find_library(sysrepo_lib_${sysrepo_lib} NAMES ${sysrepo_lib} PATHS ${PC_SYSREPO_LIBDIR} ${find_sysrepo_options})
+    mark_as_advanced(sysrepo_lib_${sysrepo_lib})
+    list(APPEND SYSREPO_LIBRARIES ${sysrepo_lib_${sysrepo_lib}})
+endforeach()
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set SYSREPO_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(sysrepo  DEFAULT_MSG
-                                  SYSREPO_LIBRARY SYSREPO_INCLUDE_DIR)
-
-mark_as_advanced(SYSREPO_INCLUDE_DIR SYSREPO_LIBRARY )
+find_package_handle_standard_args(sysrepo DEFAULT_MSG
+                                  SYSREPO_LIBRARIES SYSREPO_INCLUDE_DIRS)


### PR DESCRIPTION
As a side effect of pull request sysrepo/sysrepo#389, sysrepo.pc
pkg-config file is changed so that it now specifies both libsysrepo.so
and libsysrepo-engine.so for linking.  This patch adapts to that change
(if it gets merged) so that netopeer2 now supports linking with sysrepo
again.

I am not completely happy about this. I asked on #cmake IRC channel and
apparently The Modern Way™ would be for sysrepo to install a special
fancy cmake file which one could use to bypass pkg-config altogether. I
asked because I got puzzled by the suggested dance to take pkg-config's
results and call cmake's find_library on top of them.

Another alternative would be to add link_directories(), but that would
require calling find_module(SYSREPO) prior to defining targets -- please
indicate whether you prefer this LIST() dance, or whether you're OK with
moving this order to detect libs at first, and only then define targets.