### PR TITLE
cmake: Switch to GNUInstallDirs

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.6)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../CMakeModules/")
 
 project(netopeer2-cli C)
+include(GNUInstallDirs)
 
 # check the supported platform
 if(NOT UNIX)
@@ -59,16 +60,8 @@ if(LIBNETCONF2_ENABLED_TLS)
     include_directories(${OPENSSL_INCLUDE_DIR})
 endif()
 
-if(NOT BIN_INSTALL_DIR)
-    set(BIN_INSTALL_DIR bin)
-endif()
-
-if(NOT MAN_INSTALL_DIR)
-    set(MAN_INSTALL_DIR share/man)
-endif()
-
 # install binary
-install(TARGETS netopeer2-cli DESTINATION ${BIN_INSTALL_DIR})
+install(TARGETS netopeer2-cli DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # man -> html
 find_program(ROFF2HTML roff2html)
@@ -80,7 +73,7 @@ else()
 endif()
 
 # install doc (man)
-install(FILES ${PROJECT_SOURCE_DIR}/doc/${PROJECT_NAME}.1 DESTINATION ${MAN_INSTALL_DIR}/man1)
+install(FILES ${PROJECT_SOURCE_DIR}/doc/${PROJECT_NAME}.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 # clean cmake cache
 add_custom_target(cleancache


### PR DESCRIPTION
There's a good existing CMake module which makes this configuration
less special and more boring; it also makes Debian crossbuilds much
easier.