### PR TITLE
cmake: Use absolute path for keystored's key directory

### DIFF
--- a/keystored/CMakeLists.txt
+++ b/keystored/CMakeLists.txt
@@ -25,7 +25,7 @@ set(KEYSTORED_VERSION 0.1.1)
 
 # config variables
 if (NOT KEYSTORED_KEYS_DIR)
-    set(KEYSTORED_KEYS_DIR "${CMAKE_INSTALL_PREFIX}/etc/keystored/keys")
+    set(KEYSTORED_KEYS_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/keystored/keys")
 endif()
 if (NOT OPENSSL_EXECUTABLE)
     find_program(OPENSSL_EXECUTABLE openssl)


### PR DESCRIPTION
The correct dir doesn't live underneath /usr on a typical system, so it
should be specified as an absolute path like this.