### PR TITLE
fix edit-config using model with ordered-by user attr under leaf-list report error

### DIFF
--- a/server/op_editconfig.c
+++ b/server/op_editconfig.c
@@ -99,7 +99,7 @@ edit_get_move(struct lyd_node *node, const char *path, sr_move_position_t *pos, 
                     *pos = SR_MOVE_AFTER;
                 }
             } else if (!strcmp(attr_iter->name, name)) {
-                if (asprintf(rel, format, path, attr_iter->value_str)<0) {
+                if (asprintf(rel, format, path, attr_iter->value_str) < 0) {
                     ERR("%s: memory allocation failed (%s) - %s:%d",
                         __func__, strerror(errno), __FILE__, __LINE__);
                     return EXIT_FAILURE;

--- a/server/op_editconfig.c
+++ b/server/op_editconfig.c
@@ -99,7 +99,7 @@ edit_get_move(struct lyd_node *node, const char *path, sr_move_position_t *pos, 
                     *pos = SR_MOVE_AFTER;
                 }
             } else if (!strcmp(attr_iter->name, name)) {
-                if (asprintf(rel, format, path, attr_iter->value)) {
+                if (asprintf(rel, format, path, attr_iter->value_str)<0) {
                     ERR("%s: memory allocation failed (%s) - %s:%d",
                         __func__, strerror(errno), __FILE__, __LINE__);
                     return EXIT_FAILURE;


### PR DESCRIPTION
repeat step:
1. Install the module of module.yang. It will success.
2. Use edit-config in netopeer2-cli using init.xml to config data. It will report OK.
3. Use edit-config in netopeer2-cli using modify.xml to config data. It will report error like this:
    "message:  edit_get_move: memory allocation failed (Unknown error -8191)"

module.yang:
```
module UserByOrderTest{
	namespace "urn:ietf:params:xml:ns:yang:userbyordertest";
	prefix UserByOrderTest;
	
	container root{
		leaf-list ff{
			type string;
			ordered-by user;
		}
	}
}
```

init.xml:
```xml
<root xmlns="urn:ietf:params:xml:ns:yang:userbyordertest"
	xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
	<ff>aa</ff>
	<ff>bb</ff>
	<ff>cc</ff>
</root>
```

modify.xml
```xml
<root xmlns="urn:ietf:params:xml:ns:yang:userbyordertest"
	xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0"
	xmlns:yang="urn:ietf:params:xml:ns:yang:1">
	<ff xc:operation="create" yang:insert="before" yang:value="bb">dd</ff>
	<ff xc:operation="create" yang:insert="after" yang:value="aa">ee</ff>
</root>
```

[issue.txt](https://github.com/CESNET/Netopeer2/files/918402/issue.txt)
