### PR TITLE
BUGFIX typo in cmake

### DIFF
--- a/keystored/CMakeLists.txt
+++ b/keystored/CMakeLists.txt
@@ -122,7 +122,7 @@ install(CODE "
             message(FATAL_ERROR \"  Command sysrepoctl install failed:\\n  \${OUT}\")
         endif()
 
-        execute_process(COMMAND ${SYSREPOCTL_EXECUTABLE} -m ietf-keystore -t RESULT_VARIABLE RET OUTPUT_VARIABLE OUT ERROR_VARIABLE OUT)
+        execute_process(COMMAND ${SYSREPOCTL_EXECUTABLE} -m ietf-keystore RESULT_VARIABLE RET OUTPUT_VARIABLE OUT ERROR_VARIABLE OUT)
         if (RET)
             string(REPLACE \"\\n\" \"\\n  \" OUT \${OUT})
             message(FATAL_ERROR \"  Command sysrepoctl init failed:\\n  \${OUT}\")


### PR DESCRIPTION
Docker build for Arch linux would fail because of this typo, all other dockerfiles would pass.