### PR TITLE
After subscribe at netopeer2-cli, install new model will cause netope…

### DIFF
--- a/server/op_notifications.c
+++ b/server/op_notifications.c
@@ -176,7 +176,6 @@ np2srv_ntf_send(struct np_subscriber *subscriber, struct lyd_node *ntf, time_t t
     }
 
     free(datetime);
-    lyd_free(ntf);
 }
 
 static void
@@ -223,7 +222,6 @@ np2srv_ntf_clb(const sr_ev_notif_type_t notif_type, const char *xpath, const sr_
 
     /* send the notification */
     np2srv_ntf_send(subscriber, ntf, timestamp, notif_type);
-    return;
 
 error:
     lyd_free(ntf);


### PR DESCRIPTION
Replication step:
1. Start netopeer2-cli, netopeer2-server, enable module.
2. At netopeer2-cli, use subscribe --filter-xpath /modulename:rootname.
3. Keep netopeer2-cli and netopeer2-server alive, use sysrepoctl install new model.

Segmentation fault infomation like follow:
#0  0x00007f2289d69ce8 in lyd_free (node=0x7f228000b9b0) at /nfoam/libyang/src/tree_data.c:4948
#1  0x00000000004174d5 in op_ntf_yang_lib_change (ylib_info=0x7f2280007290) at /nfoam/netopeer2/server/op_notifications.c:522
#2  0x0000000000407cc8 in np2srv_module_install_clb (module_name=0x7f228000187b "CmInstall", revision=0x0, state=SR_MS_IMPLEMENTED, 
    UNUSED_private_ctx=0x0) at /nfoam/netopeer2/server/main.c:458
#3  0x00007f22897fea91 in cl_sm_notif_process (sm_ctx=0x25934b0, conn=0x7f2280001180, msg=0x7f2280001788)
    at /nfoam/sysrepo/src/clientlib/cl_subscription_manager.c:681
#4  0x00007f2289803509 in cl_sm_conn_msg_process (sm_ctx=0x25934b0, conn=0x7f2280001180, msg_data=0x7f22800012b4 "\b\003\020", msg_size=122)
    at /nfoam/sysrepo/src/clientlib/cl_subscription_manager.c:1213
#5  0x00007f2289803ba1 in cl_sm_conn_in_buff_process (sm_ctx=0x25934b0, conn=0x7f2280001180)
    at /nfoam/sysrepo/src/clientlib/cl_subscription_manager.c:1265
#6  0x00007f22898046b1 in cl_sm_fd_read_data (sm_ctx=0x25934b0, fd=6)
    at /nfoam/sysrepo/src/clientlib/cl_subscription_manager.c:1350
#7  0x00007f2289804a57 in cl_sm_fd_read_cb (loop=0x2595950, w=0x7f22800011d0, revents=1)
    at /nfoam/sysrepo/src/clientlib/cl_subscription_manager.c:1378
#8  0x00007f2287a27465 in ev_invoke_pending () from //nfoam/deplib/libev.so.4
#9  0x00007f2287a2a5c7 in ev_run () from //nfoam/deplib/libev.so.4
#10 0x00007f22898085ed in cl_sm_event_loop_threaded (sm_ctx_p=0x25934b0)
    at /nfoam/sysrepo/src/clientlib/cl_subscription_manager.c:1789
