### PR TITLE
server BUGFIX replace sr_get_iter with sr_get_items

### DIFF
--- a/server/ietf_netconf_server.c
+++ b/server/ietf_netconf_server.c
@@ -1161,8 +1161,8 @@ feature_change_ietf_netconf_server(const char *feature_name, bool enabled)
 {
     int rc, rc2 = 0;
     const char *path = NULL;
-    sr_val_iter_t *sr_iter;
-    sr_val_t *sr_val;
+    sr_val_t *values;
+    size_t value_cnt;
 
     assert(feature_name);
 
@@ -1180,26 +1180,26 @@ feature_change_ietf_netconf_server(const char *feature_name, bool enabled)
             return EXIT_SUCCESS;
         }
 
-        rc = sr_get_items_iter(np2srv.sr_sess.srs, path, &sr_iter);
+        rc =sr_get_items(np2srv.sr_sess.srs, path, &values, &value_cnt);
         if (rc != SR_ERR_OK) {
             ERR("Failed to get \"%s\" values iterator from sysrepo (%s).", sr_strerror(rc));
             return EXIT_FAILURE;
         }
 
-        while ((rc = sr_get_item_next(np2srv.sr_sess.srs, sr_iter, &sr_val)) == SR_ERR_OK) {
-            if (sr_val->type == SR_LIST_T) {
+        size_t i;
+        for(i = 0; i < value_cnt; i++) {
+            if (values[i].type == SR_LIST_T) {
                 /* no semantic meaning */
                 continue;
             }
 
-            rc2 = module_change_resolve(np2srv.sr_sess.srs, SR_OP_CREATED, NULL, sr_val, NULL, NULL);
-            sr_free_val(sr_val);
+            rc2 = module_change_resolve(np2srv.sr_sess.srs, SR_OP_CREATED, NULL, &values[i], NULL, NULL);
             if (rc2) {
                 ERR("Failed to enable nodes depending on the \"%s\" ietf-netconf-server feature.", feature_name);
                 break;
             }
         }
-        sr_free_val_iter(sr_iter);
+        sr_free_values(values, value_cnt);
         if (rc2) {
             return EXIT_FAILURE;
         } else if ((rc != SR_ERR_OK) && (rc != SR_ERR_NOT_FOUND)) {


### PR DESCRIPTION
Hi,

This fixes the github issue https://github.com/sysrepo/sysrepo/issues/920.

So when a fresh Sysrepo/Netopeer2 docker container has been created with the default cmake values, netopeer2 crashes. To fix it I need to disable tls features in ietf-netconf-server and add this patch.

It seems that with sr_get_items_iter sysrepo thinks it has more values when it is finished while with sr_get_items it has allocated all of the values at the start.

@rkrejci I am not sure if I can use sr_get_items instead of sr_get_items_iter because of the function module_change_resolve. Can you take a look.

Regards,
Mislav 