### PR TITLE
fix a crash issue

### DIFF
--- a/server/ietf_netconf_server.c
+++ b/server/ietf_netconf_server.c
@@ -1182,7 +1182,7 @@ feature_change_ietf_netconf_server(const char *feature_name, bool enabled)
 
         rc = sr_get_items_iter(np2srv.sr_sess.srs, path, &sr_iter);
         if (rc != SR_ERR_OK) {
-            ERR("Failed to get \"%s\" values iterator from sysrepo (%s).", sr_strerror(rc));
+            ERR("Failed to get \"%s\" values iterator from sysrepo (%s).", path, sr_strerror(rc));
             return EXIT_FAILURE;
         }
 


### PR DESCRIPTION
insufficient arguments of ERR lead to crash.

Signed-off-by: Jimmy, Chun-Tsung Wang <jimmy.wang@zyxel.com.tw>