### PR TITLE
server BUGFIX for compile errors on glibc

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -13,6 +13,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
+#define _GNU_SOURCE
 #define _DEFAULT_SOURCE 1
 #define _POSIX_C_SOURCE 200809L
 #include <errno.h>


### PR DESCRIPTION
I had a problem with compiling netopeer2-server on OpenWrt (glibc), to fix this I had add `#define _GNU_SOURCE`.

I'm not sure does this contradict other defines in the C file?

Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>