### PR TITLE
double free issue about notification 

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -636,7 +636,6 @@ np2srv_new_session_clb(const char *UNUSED(client_name), struct nc_session *new_s
             ncm_session_del(new_session);
         }
         nc_session_free(new_session, free_ds);
-        return;
     }
 
     if ((mod = ly_ctx_get_module(np2srv.ly_ctx, "ietf-netconf-notifications", NULL, 1))) {

--- a/server/main.c
+++ b/server/main.c
@@ -636,6 +636,7 @@ np2srv_new_session_clb(const char *UNUSED(client_name), struct nc_session *new_s
             ncm_session_del(new_session);
         }
         nc_session_free(new_session, free_ds);
+        return;
     }
 
     if ((mod = ly_ctx_get_module(np2srv.ly_ctx, "ietf-netconf-notifications", NULL, 1))) {

--- a/server/op_notifications.c
+++ b/server/op_notifications.c
@@ -144,7 +144,6 @@ np2srv_ntf_send(struct np_subscriber *subscriber, struct lyd_node *ntf, time_t t
             for (i = 0; i < subscriber->filter_count; ++i) {
                 if (op_filter_get_tree_from_data(&filtered_ntf, ntf, subscriber->filters[i])) {
                     free(datetime);
-                    lyd_free(ntf);
                     lyd_free(filtered_ntf);
                     return;
                 }


### PR DESCRIPTION
Hi ,
please have a look.

in function np2srv_ntf_clb end, it will free ntf,

but, in np2srv_ntf_send, if call op_filter_get_tree_from_data failed, it would free ntf also.

in this case, the ntf would be freed twice. it would case crash.