### PR TITLE
Listening on both ipv6 and ipv4 addresses

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -1029,7 +1029,7 @@ server_init(void)
         if (nc_server_add_endpt("main", NC_TI_LIBSSH)) {
             goto error;
         }
-        if (nc_server_endpt_set_address("main", "0.0.0.0")) {
+        if (nc_server_endpt_set_address("main", "::")) {
             goto error;
         }
         if (nc_server_endpt_set_port("main", 830)) {


### PR DESCRIPTION
 Using "::" as the binding address could listening on local ipv6 and local ipv4 addresses.

Reference

https://github.com/nodejs/node/issues/9390


List here


OS | Listen IPv6 address | Does equivalent IPv4 auto listened
-- | -- | --
Windows 7Pro/10 | :: | YES
Mac OS X EI Capitan 10.11.6 | :: | YES
Ubuntu 14.04/16.04 | :: | YES
Windows 7Pro/10 | ::1 | NO
Mac OS X EI Capitan 10.11.6 | ::1 | NO
Ubuntu 14.04/16.04 | ::1 | NO
Windows 7Pro/10 | ActualIPv6Address | NO
Mac OS X EI Capitan 10.11.6 | ActualIPv6Address | NO
Ubuntu 16.10 | ActualIPv6Address | NO

