### PR TITLE
cli BUGFIX segfault when get-schema returns empty data

### DIFF
--- a/cli/commands.c
+++ b/cli/commands.c
@@ -284,13 +284,15 @@ recv_reply:
 
         /* special case */
         if (nc_rpc_get_type(rpc) == NC_RPC_GETSCHEMA) {
-            if (output == stdout) {
-                fprintf(output, "MODULE\n");
-            }
-            if ((data_rpl->data->schema->nodetype != LYS_RPC) || (data_rpl->data->child->schema->nodetype != LYS_ANYXML)) {
+            if ((data_rpl->data->schema->nodetype != LYS_RPC) ||
+                (data_rpl->data->child == NULL) ||
+                (data_rpl->data->child->schema->nodetype != LYS_ANYXML)) {
                 ERROR(__func__, "Unexpected data reply to <get-schema> RPC.");
                 ret = -1;
                 break;
+            }
+            if (output == stdout) {
+                fprintf(output, "MODULE\n");
             }
             any = (struct lyd_node_anydata *)data_rpl->data->child;
             switch (any->value_type) {


### PR DESCRIPTION
When the target of get-schema is not found, some device is replying some thing like:
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="100">
    <data/>
</rpc-reply>
```
causing segment fault in netopeer2-cli. Add checking to fix this.