### PR TITLE
Fix enabling a feature that depends on a feature in a subsequent schema

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -754,10 +754,19 @@ np2srv_init_schemas(void)
     char *data = NULL;
     const struct lys_module *mod;
     sr_schema_t *schemas = NULL;
-    size_t count, i, j;
+    size_t schema_count, i, j;
+
+    size_t module_feature_count = 0;
+    struct mod_feat {
+        const struct lys_module *mod;
+        const char *enabled_feature;
+    };
+    struct mod_feat *mod_feat_array;
+    size_t mod_feat_array_index;
+    bool making_progress;
 
     /* get the list of schemas from sysrepo */
-    if (np2srv_sr_list_schemas(np2srv.sr_sess.srs, &schemas, &count, NULL)) {
+    if (np2srv_sr_list_schemas(np2srv.sr_sess.srs, &schemas, &schema_count, NULL)) {
         return -1;
     }
 
@@ -805,7 +814,7 @@ np2srv_init_schemas(void)
     ly_ctx_set_module_imp_clb(np2srv.ly_ctx, np2srv_ly_import_clb, NULL);
 
     /* 1) use modules from sysrepo */
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < schema_count; i++) {
         data = NULL;
         mod = NULL;
         VRB("Loading schema \"%s%s%s\" from sysrepo.", schemas[i].module_name, schemas[i].revision.revision ? "@" : "",
@@ -824,23 +833,78 @@ np2srv_init_schemas(void)
             mod = lys_parse_mem(np2srv.ly_ctx, data, LYS_IN_YIN);
             free(data);
         }
+    }
 
-        if (!mod) {
+    /* determine the count of module/features present */
+    module_feature_count = 0;
+    for (i=0; i < schema_count; i++) {
+        module_feature_count += schemas[i].enabled_feature_cnt;
+    }
+    /* prepare data storage to keep module/feature enable status */
+    mod_feat_array = calloc(module_feature_count, sizeof (struct mod_feat));
+    mod_feat_array_index = 0;
+
+    /* loop back through the modules now that they should be loaded and enable features */
+    for (i = 0; i < schema_count; i++) {
+        if ((mod = ly_ctx_get_module(np2srv.ly_ctx, schemas[i].module_name, schemas[i].revision.revision, 0))) {
+            /* set features according to sysrepo */
+            for (j = 0; j < schemas[i].enabled_feature_cnt; ++j) {
+                /* if lys_features_enable fail, record the mod_feat for retry otherwise store a null */
+                if (lys_features_enable(mod, schemas[i].enabled_features[j]) == EXIT_FAILURE) {
+                    /* store away info related to feature that did not enable on first pass */
+                    mod_feat_array[mod_feat_array_index].mod = mod;
+                    mod_feat_array[mod_feat_array_index].enabled_feature = schemas[i].enabled_features[j];
+                }
+                mod_feat_array_index++;
+            }
+        } else {
             WRN("Getting %s%s%s schema from sysrepo failed, data from this module won't be available.",
                 schemas[i].module_name, schemas[i].revision.revision ? "@" : "",
                 schemas[i].revision.revision ? schemas[i].revision.revision : "");
-        } else {
-            /* set features according to sysrepo */
-            for (j = 0; j < schemas[i].enabled_feature_cnt; ++j) {
-                lys_features_enable(mod, schemas[i].enabled_features[j]);
-            }
+        }
+    }
 
-            /* set RPC and Notifications callbacks */
+    /* we may be able to get features enabled now that others are enabled so we will
+       run through our stored module_features and retry the ones on our list
+       we will continue until a pass through the array doesn't indicate progress */
+    making_progress = true;
+    while(making_progress) {
+        making_progress = false;
+        for (i = 0; i < module_feature_count; i++) {
+            if (mod_feat_array[i].mod != NULL) {
+                if ((lys_features_enable(mod_feat_array[i].mod, mod_feat_array[i].enabled_feature)) == EXIT_SUCCESS) {
+                    /* feature enabled, remove from list and set making_progress TRUE */
+                    VRB("Retry feature enable successful for \"%s\" in \"%s\".",
+                        mod_feat_array[i].enabled_feature, mod_feat_array[i].mod->name);
+                    making_progress = true;
+                    mod_feat_array[i].mod = NULL;
+                    mod_feat_array[i].enabled_feature = NULL;
+                }
+            }
+        }
+    }
+
+    /* now pass through the mod_feat_array and report ERR on any remaining entries
+       as they are not enabled */
+    for (i = 0; i < module_feature_count; i++) {
+        if (mod_feat_array[i].mod != NULL) {
+            /* this module feature never enabled */
+            ERR("Retry feature enable failed for \"%s\" in \"%s\".",
+                mod_feat_array[i].enabled_feature, mod_feat_array[i].mod->name);
+        }
+    }
+
+    free(mod_feat_array);
+
+    for (i = 0; i < schema_count; i++) {
+        if ((mod = ly_ctx_get_module(np2srv.ly_ctx, schemas[i].module_name, schemas[i].revision.revision, 0))) {
+            /* setRPC and Notifications callbacks */
             np2srv_module_assign_clbs(mod);
         }
     }
+
     ly_ctx_set_module_imp_clb(np2srv.ly_ctx, np2srv_ly_import_clb, NULL);
-    sr_free_schemas(schemas, count);
+    sr_free_schemas(schemas, schema_count);
     schemas = NULL;
 
     /* 2) add internally used schemas: ietf-netconf, ... */
@@ -893,7 +957,7 @@ np2srv_init_schemas(void)
 
 error:
     if (schemas) {
-        sr_free_schemas(schemas, count);
+        sr_free_schemas(schemas, schema_count);
     }
     ly_ctx_destroy(np2srv.ly_ctx, NULL);
     return -1;

--- a/server/tests/config.h.in
+++ b/server/tests/config.h.in
@@ -124,6 +124,10 @@ __wrap_sr_get_schema(sr_session_ctx_t *session, const char *module_name, const c
         fd = open(TESTS_DIR "/files/nc-notifications.yin", O_RDONLY);
     } else if (!strcmp(module_name, "test-notif")) {
         fd = open(TESTS_DIR "/files/test-notif.yin", O_RDONLY);
+    } else if (!strcmp(module_name, "test-feature")) {
+        fd = open(TESTS_DIR "/files/test-feature.yin", O_RDONLY);
+    } else if (!strcmp(module_name, "test-feature-consumer")) {
+        fd = open(TESTS_DIR "/files/test-feature-consumer.yin", O_RDONLY);
     } else {
         return SR_ERR_NOT_FOUND;
     }

--- a/server/tests/files/test-feature-consumer.yin
+++ b/server/tests/files/test-feature-consumer.yin
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="test-feature-consumer"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:tfc="urn:ietf:params:xml:ns:yang:test-feature-consumer"
+        xmlns:tf="urn:ietf:params:xml:ns:yang:test-feature">
+  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature-consumer"/>
+  <prefix value="tfc"/>
+  <import module="test-feature">
+    <prefix value="tf"/>
+  </import>
+  <revision date="2018-05-18">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>None.</text>
+    </reference>
+  </revision>
+  <feature name="dependent-feature">
+    <if-feature name="tf:controlling-feature"/>
+  </feature>
+  <container name="test-container">
+    <if-feature name="dependent-feature"/>
+    <leaf name="test-leaf">
+      <type name="string"/>
+    </leaf>
+  </container>
+</module>

--- a/server/tests/files/test-feature.yin
+++ b/server/tests/files/test-feature.yin
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="test-feature"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:tf="urn:ietf:params:xml:ns:yang:test-feature">
+  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature"/>
+  <prefix value="tf"/>
+  <revision date="2018-05-18">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>None.</text>
+    </reference>
+  </revision>
+  <feature name="controlling-feature">
+    <description>
+      <text>A controlling feature</text>
+    </description>
+  </feature>
+</module>

--- a/server/tests/test_edit_get_config.c
+++ b/server/tests/test_edit_get_config.c
@@ -72,9 +72,9 @@ __wrap_sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t 
 {
     (void)session;
 
-    *schema_cnt = 4;
+    *schema_cnt = 6;
 
-    *schemas = calloc(4, sizeof **schemas);
+    *schemas = calloc(6, sizeof **schemas);
 
     (*schemas)[0].module_name = strdup("ietf-netconf-server");
     (*schemas)[0].installed = 1;
@@ -106,6 +106,26 @@ __wrap_sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t 
     (*schemas)[3].revision.revision = strdup("2014-05-08");
     (*schemas)[3].revision.file_path_yin = strdup(TESTS_DIR"/files/iana-if-type.yin");
     (*schemas)[3].installed = 1;
+
+    (*schemas)[4].module_name = strdup("test-feature-consumer");
+    (*schemas)[4].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature-consumer");
+    (*schemas)[4].prefix = strdup("tfc");
+    (*schemas)[4].revision.revision = strdup("2018-05-18");
+    (*schemas)[4].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature-consumer.yin");
+    (*schemas)[4].enabled_features = malloc(sizeof(char *));
+    (*schemas)[4].enabled_features[0] = strdup("dependent-feature");
+    (*schemas)[4].enabled_feature_cnt = 1;
+    (*schemas)[4].installed = 1;
+
+    (*schemas)[5].module_name = strdup("test-feature");
+    (*schemas)[5].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature");
+    (*schemas)[5].prefix = strdup("tf");
+    (*schemas)[5].revision.revision = strdup("2018-05-18");
+    (*schemas)[5].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature.yin");
+    (*schemas)[5].enabled_features = malloc(sizeof(char *));
+    (*schemas)[5].enabled_features[0] = strdup("controlling-feature");
+    (*schemas)[5].enabled_feature_cnt = 1;
+    (*schemas)[5].installed = 1;
 
     return SR_ERR_OK;
 }
@@ -208,7 +228,7 @@ __wrap_sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t
     char *path;
     (void)session;
 
-    if (!strcmp(xpath, "/ietf-interfaces:*//.")) {
+    if (!strcmp(xpath, "/ietf-interfaces:*//.") || !strcmp(xpath, "/test-feature-consumer:*//.")) {
         if (!ietf_if_set) {
             ietf_if_set = lyd_find_path(data, xpath);
         }
@@ -1110,7 +1130,7 @@ test_edit_create3(void **state)
 }
 
 static void
-test_edit_merge(void **state)
+test_edit_merge1(void **state)
 {
     (void)state; /* unused */
     const char *get_config_rpc =
@@ -1317,6 +1337,135 @@ test_edit_merge(void **state)
 }
 
 static void
+test_edit_merge2(void **state)
+{
+    (void)state; /* unused */
+    const char *get_config_rpc =
+    "<rpc msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<get-config>"
+            "<source>"
+                "<running/>"
+            "</source>"
+        "</get-config>"
+    "</rpc>";
+    const char *get_config_rpl =
+    "<rpc-reply msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<data xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+"<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">"
+  "<interface>"
+    "<name>iface2</name>"
+    "<description>iface2 dsc</description>"
+    "<type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:softwareLoopback</type>"
+    "<enabled>false</enabled>"
+    "<link-up-down-trap-enable>disabled</link-up-down-trap-enable>"
+    "<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<address>"
+        "<ip>10.0.0.5</ip>"
+        "<netmask>255.0.0.0</netmask>"
+      "</address>"
+      "<address>"
+        "<ip>172.0.0.5</ip>"
+        "<prefix-length>16</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>10.0.0.1</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:fa</link-layer-address>"
+      "</neighbor>"
+    "</ipv4>"
+    "<ipv6 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<address>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:5</ip>"
+        "<prefix-length>64</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:1</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:fa</link-layer-address>"
+      "</neighbor>"
+      "<dup-addr-detect-transmits>100</dup-addr-detect-transmits>"
+      "<autoconf>"
+        "<create-global-addresses>true</create-global-addresses>"
+        "<create-temporary-addresses>false</create-temporary-addresses>"
+        "<temporary-valid-lifetime>600</temporary-valid-lifetime>"
+        "<temporary-preferred-lifetime>300</temporary-preferred-lifetime>"
+      "</autoconf>"
+    "</ipv6>"
+  "</interface>"
+  "<interface>"
+    "<name>iface1</name>"
+    "<description>iface1 dsc</description>"
+    "<type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>"
+    "<enabled>true</enabled>"
+    "<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<enabled>true</enabled>"
+      "<forwarding>true</forwarding>"
+      "<mtu>68</mtu>"
+      "<address>"
+        "<ip>10.0.0.1</ip>"
+        "<netmask>255.0.0.0</netmask>"
+      "</address>"
+      "<address>"
+        "<ip>172.0.0.1</ip>"
+        "<prefix-length>16</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>10.0.0.2</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:f0</link-layer-address>"
+      "</neighbor>"
+    "</ipv4>"
+    "<ipv6 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<enabled>true</enabled>"
+      "<forwarding>false</forwarding>"
+      "<mtu>1280</mtu>"
+      "<address>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:1</ip>"
+        "<prefix-length>64</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:2</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:f0</link-layer-address>"
+      "</neighbor>"
+      "<dup-addr-detect-transmits>52</dup-addr-detect-transmits>"
+      "<autoconf>"
+        "<create-global-addresses>true</create-global-addresses>"
+        "<create-temporary-addresses>false</create-temporary-addresses>"
+        "<temporary-valid-lifetime>600</temporary-valid-lifetime>"
+        "<temporary-preferred-lifetime>300</temporary-preferred-lifetime>"
+      "</autoconf>"
+    "</ipv6>"
+    "<link-up-down-trap-enable>disabled</link-up-down-trap-enable>"
+  "</interface>"
+"</interfaces>"
+"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-consumer\">"
+  "<test-leaf>green</test-leaf>"
+"</test-container>"
+        "</data>"
+    "</rpc-reply>";
+    const char *edit_rpc =
+    "<rpc msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<edit-config>"
+            "<target>"
+                "<running/>"
+            "</target>"
+            "<config>"
+"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-consumer\">"
+  "<test-leaf>green</test-leaf>"
+"</test-container>"
+            "</config>"
+        "</edit-config>"
+    "</rpc>";
+    const char *edit_rpl =
+    "<rpc-reply msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<ok/>"
+    "</rpc-reply>";
+
+    test_write(p_out, edit_rpc, __LINE__);
+    test_read(p_in, edit_rpl, __LINE__);
+
+    test_write(p_out, get_config_rpc, __LINE__);
+    test_read(p_in, get_config_rpl, __LINE__);
+}
+
+static void
 test_startstop(void **state)
 {
     (void)state; /* unused */
@@ -1335,7 +1484,8 @@ main(void)
                     cmocka_unit_test(test_edit_create1),
                     cmocka_unit_test(test_edit_create2),
                     cmocka_unit_test(test_edit_create3),
-                    cmocka_unit_test(test_edit_merge),
+                    cmocka_unit_test(test_edit_merge1),
+                    cmocka_unit_test(test_edit_merge2),
                     cmocka_unit_test_teardown(test_startstop, np_stop),
     };
 


### PR DESCRIPTION
### Description
`np2srv_init_schemas()` walks through schemas in the order they are returned from sysrepo via `np2srv_sr_list_schemas()` and attemps to enable features that sysrepo indicates are supposed to be enabled.

However, if a feature in schema `n` depends on a feature that is found in schema `n + 1` (or any subsequent schema, for that matter), enabling the feature in schema `n` will fail because the feature in schema `n + 1` has not yet been enabled.

The additional unit test included in this commit demonstrates the problem.

### Solution
This commit implements a solution as follows:
1. When walking through the schemas returned from sysrepo, keep a list containing all the features that will need to be enabled.
2. Now walk through all the schemas attempting to enable the recorded features. Some features may fail to enable due to depending on other features that have not yet been enabled. So continue walking through the schemas attempting to enable features as long as (1) we are able to make progress and enable at least one new feature, or (2) there are no more features to enable.

This approach should allow us to enable all of the required features regardless of how far apart they are on a dependency graph.