### PR TITLE
Fix longer feature dependency chains (see #248)

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -872,7 +872,7 @@ np2srv_init_schemas(void)
        run through our stored module_features and retry the ones on our list
        we will continue until a pass through the array doesn't indicate progress */
     ly_lo = ly_log_options(0);
-    making_progress = false;
+    making_progress = true;
     while (making_progress) {
         making_progress = false;
         for (i = 0; i < module_feature_count; i++) {

--- a/server/main.c
+++ b/server/main.c
@@ -872,8 +872,7 @@ np2srv_init_schemas(void)
        run through our stored module_features and retry the ones on our list
        we will continue until a pass through the array doesn't indicate progress */
     ly_lo = ly_log_options(0);
-    making_progress = true;
-    while (making_progress) {
+    do {
         making_progress = false;
         for (i = 0; i < module_feature_count; i++) {
             if (mod_feat_array[i].mod) {
@@ -885,7 +884,7 @@ np2srv_init_schemas(void)
                 }
             }
         }
-    }
+    } while (making_progress);
     ly_log_options(ly_lo);
 
     /* now pass through the mod_feat_array and report errors on any remaining entries

--- a/server/tests/config.h.in
+++ b/server/tests/config.h.in
@@ -124,10 +124,12 @@ __wrap_sr_get_schema(sr_session_ctx_t *session, const char *module_name, const c
         fd = open(TESTS_DIR "/files/nc-notifications.yin", O_RDONLY);
     } else if (!strcmp(module_name, "test-notif")) {
         fd = open(TESTS_DIR "/files/test-notif.yin", O_RDONLY);
-    } else if (!strcmp(module_name, "test-feature")) {
-        fd = open(TESTS_DIR "/files/test-feature.yin", O_RDONLY);
-    } else if (!strcmp(module_name, "test-feature-consumer")) {
-        fd = open(TESTS_DIR "/files/test-feature-consumer.yin", O_RDONLY);
+    } else if (!strcmp(module_name, "test-feature-a")) {
+        fd = open(TESTS_DIR "/files/test-feature-a.yin", O_RDONLY);
+    } else if (!strcmp(module_name, "test-feature-b")) {
+        fd = open(TESTS_DIR "/files/test-feature-b.yin", O_RDONLY);
+    } else if (!strcmp(module_name, "test-feature-c")) {
+        fd = open(TESTS_DIR "/files/test-feature-c.yin", O_RDONLY);
     } else {
         return SR_ERR_NOT_FOUND;
     }

--- a/server/tests/files/test-feature-a.yin
+++ b/server/tests/files/test-feature-a.yin
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module name="test-feature"
+<module name="test-feature-a"
         xmlns="urn:ietf:params:xml:ns:yang:yin:1"
-        xmlns:tf="urn:ietf:params:xml:ns:yang:test-feature">
-  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature"/>
-  <prefix value="tf"/>
+        xmlns:tfa="urn:ietf:params:xml:ns:yang:test-feature-a">
+  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature-a"/>
+  <prefix value="tfa"/>
   <revision date="2018-05-18">
     <description>
       <text>Initial revision.</text>
@@ -12,9 +12,9 @@
       <text>None.</text>
     </reference>
   </revision>
-  <feature name="controlling-feature">
+  <feature name="test-feature-a">
     <description>
-      <text>A controlling feature</text>
+      <text>Test feature A</text>
     </description>
   </feature>
 </module>

--- a/server/tests/files/test-feature-b.yin
+++ b/server/tests/files/test-feature-b.yin
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="test-feature-b"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:tfb="urn:ietf:params:xml:ns:yang:test-feature-b"
+        xmlns:tfa="urn:ietf:params:xml:ns:yang:test-feature-a">
+  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature-b"/>
+  <prefix value="tfb"/>
+  <import module="test-feature-a">
+    <prefix value="tfa"/>
+  </import>
+  <revision date="2018-05-18">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>None.</text>
+    </reference>
+  </revision>
+  <feature name="test-feature-b">
+    <if-feature name="tfa:test-feature-a"/>
+  </feature>
+</module>

--- a/server/tests/files/test-feature-c.yin
+++ b/server/tests/files/test-feature-c.yin
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module name="test-feature-consumer"
+<module name="test-feature-c"
         xmlns="urn:ietf:params:xml:ns:yang:yin:1"
-        xmlns:tfc="urn:ietf:params:xml:ns:yang:test-feature-consumer"
-        xmlns:tf="urn:ietf:params:xml:ns:yang:test-feature">
-  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature-consumer"/>
+        xmlns:tfc="urn:ietf:params:xml:ns:yang:test-feature-c"
+        xmlns:tfb="urn:ietf:params:xml:ns:yang:test-feature-b">
+  <namespace uri="urn:ietf:params:xml:ns:yang:test-feature-c"/>
   <prefix value="tfc"/>
-  <import module="test-feature">
-    <prefix value="tf"/>
+  <import module="test-feature-b">
+    <prefix value="tfb"/>
   </import>
   <revision date="2018-05-18">
     <description>
@@ -16,11 +16,11 @@
       <text>None.</text>
     </reference>
   </revision>
-  <feature name="dependent-feature">
-    <if-feature name="tf:controlling-feature"/>
+  <feature name="test-feature-c">
+    <if-feature name="tfb:test-feature-b"/>
   </feature>
   <container name="test-container">
-    <if-feature name="dependent-feature"/>
+    <if-feature name="test-feature-c"/>
     <leaf name="test-leaf">
       <type name="string"/>
     </leaf>

--- a/server/tests/test_edit_get_config.c
+++ b/server/tests/test_edit_get_config.c
@@ -72,9 +72,9 @@ __wrap_sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t 
 {
     (void)session;
 
-    *schema_cnt = 6;
+    *schema_cnt = 7;
 
-    *schemas = calloc(6, sizeof **schemas);
+    *schemas = calloc(*schema_cnt, sizeof **schemas);
 
     (*schemas)[0].module_name = strdup("ietf-netconf-server");
     (*schemas)[0].installed = 1;
@@ -107,25 +107,35 @@ __wrap_sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t 
     (*schemas)[3].revision.file_path_yin = strdup(TESTS_DIR"/files/iana-if-type.yin");
     (*schemas)[3].installed = 1;
 
-    (*schemas)[4].module_name = strdup("test-feature-consumer");
-    (*schemas)[4].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature-consumer");
+    (*schemas)[4].module_name = strdup("test-feature-c");
+    (*schemas)[4].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature-c");
     (*schemas)[4].prefix = strdup("tfc");
     (*schemas)[4].revision.revision = strdup("2018-05-18");
-    (*schemas)[4].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature-consumer.yin");
+    (*schemas)[4].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature-c.yin");
     (*schemas)[4].enabled_features = malloc(sizeof(char *));
-    (*schemas)[4].enabled_features[0] = strdup("dependent-feature");
+    (*schemas)[4].enabled_features[0] = strdup("test-feature-c");
     (*schemas)[4].enabled_feature_cnt = 1;
     (*schemas)[4].installed = 1;
 
-    (*schemas)[5].module_name = strdup("test-feature");
-    (*schemas)[5].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature");
-    (*schemas)[5].prefix = strdup("tf");
+    (*schemas)[5].module_name = strdup("test-feature-b");
+    (*schemas)[5].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature-b");
+    (*schemas)[5].prefix = strdup("tfb");
     (*schemas)[5].revision.revision = strdup("2018-05-18");
-    (*schemas)[5].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature.yin");
+    (*schemas)[5].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature-b.yin");
     (*schemas)[5].enabled_features = malloc(sizeof(char *));
-    (*schemas)[5].enabled_features[0] = strdup("controlling-feature");
+    (*schemas)[5].enabled_features[0] = strdup("test-feature-b");
     (*schemas)[5].enabled_feature_cnt = 1;
     (*schemas)[5].installed = 1;
+
+    (*schemas)[6].module_name = strdup("test-feature-a");
+    (*schemas)[6].ns = strdup("urn:ietf:params:xml:ns:yang:test-feature-a");
+    (*schemas)[6].prefix = strdup("tfa");
+    (*schemas)[6].revision.revision = strdup("2018-05-18");
+    (*schemas)[6].revision.file_path_yin = strdup(TESTS_DIR"/files/test-feature-a.yin");
+    (*schemas)[6].enabled_features = malloc(sizeof(char *));
+    (*schemas)[6].enabled_features[0] = strdup("test-feature-a");
+    (*schemas)[6].enabled_feature_cnt = 1;
+    (*schemas)[6].installed = 1;
 
     return SR_ERR_OK;
 }
@@ -228,7 +238,7 @@ __wrap_sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t
     char *path;
     (void)session;
 
-    if (!strcmp(xpath, "/ietf-interfaces:*//.") || !strcmp(xpath, "/test-feature-consumer:*//.")) {
+    if (!strcmp(xpath, "/ietf-interfaces:*//.") || !strcmp(xpath, "/test-feature-c:*//.")) {
         if (!ietf_if_set) {
             ietf_if_set = lyd_find_path(data, xpath);
         }
@@ -1435,7 +1445,7 @@ test_edit_merge2(void **state)
     "<link-up-down-trap-enable>disabled</link-up-down-trap-enable>"
   "</interface>"
 "</interfaces>"
-"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-consumer\">"
+"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-c\">"
   "<test-leaf>green</test-leaf>"
 "</test-container>"
         "</data>"
@@ -1447,7 +1457,7 @@ test_edit_merge2(void **state)
                 "<running/>"
             "</target>"
             "<config>"
-"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-consumer\">"
+"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-c\">"
   "<test-leaf>green</test-leaf>"
 "</test-container>"
             "</config>"


### PR DESCRIPTION
This is a follow-up to pull request #248, which fixed a problem enabling a feature that depended on a feature in a subsequent schema that had not yet been enabled.

The follow-up optimizations in commit 6cb1612 inadvertently changed the desired behavior, in that a feature dependency chain more than two features deep will no longer be enabled properly. The problem is that the `making_progress` loop in main.c line 876 is never entered.

This change should address the issue. I've also included a change to the original unit test from #248, so that the test now demonstrates a feature dependency chain three features deep, instead of the original test which was only two features deep and did not catch the issue above.