### PR TITLE
cmake: Do not clutter up the source dir during build

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -22,7 +22,8 @@ set(CMAKE_C_FLAGS_DEBUG   "-g -O0")
 
 # set version
 set(NP2CLI_VERSION 2.0.45)
-configure_file("${PROJECT_SOURCE_DIR}/version.h.in" "${PROJECT_SOURCE_DIR}/version.h" ESCAPE_QUOTES @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/version.h.in" "${PROJECT_BINARY_DIR}/version.h" ESCAPE_QUOTES @ONLY)
+include_directories(${PROJECT_BINARY_DIR})
 
 # source files
 set(srcs

--- a/keystored/CMakeLists.txt
+++ b/keystored/CMakeLists.txt
@@ -34,7 +34,8 @@ if (NOT OPENSSL_EXECUTABLE)
     endif()
 endif()
 
-configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_SOURCE_DIR}/config.h" ESCAPE_QUOTES @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_BINARY_DIR}/config.h" ESCAPE_QUOTES @ONLY)
+include_directories(${PROJECT_BINARY_DIR})
 
 # keystored plugin
 add_library(keystored SHARED keystored.c)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -243,7 +243,8 @@ if (ENABLE_CONFIGURATION)
         endif()")
 endif()
 
-configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_SOURCE_DIR}/config.h" ESCAPE_QUOTES @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_BINARY_DIR}/config.h" ESCAPE_QUOTES @ONLY)
+include_directories(${PROJECT_BINARY_DIR})
 
 # clean cmake cache
 add_custom_target(cleancache

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -74,7 +74,7 @@ foreach(test_name IN LISTS tests)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
 endforeach(test_name)
 
-configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_SOURCE_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_BINARY_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
 
 if(ENABLE_VALGRIND_TESTS)
     find_program(valgrind_FOUND valgrind)

--- a/server/tests/test_close_session.c
+++ b/server/tests/test_close_session.c
@@ -23,10 +23,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_copy_config.c
+++ b/server/tests/test_copy_config.c
@@ -29,10 +29,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_edit_get_config.c
+++ b/server/tests/test_edit_get_config.c
@@ -29,10 +29,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_generic.c
+++ b/server/tests/test_generic.c
@@ -24,10 +24,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_get.c
+++ b/server/tests/test_get.c
@@ -24,10 +24,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_kill.c
+++ b/server/tests/test_kill.c
@@ -23,10 +23,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_notif.c
+++ b/server/tests/test_notif.c
@@ -27,10 +27,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 

--- a/server/tests/test_un_lock.c
+++ b/server/tests/test_un_lock.c
@@ -24,10 +24,10 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "config.h"
+#include "tests/config.h"
 
 #define main server_main
-#include "../config.h"
+#include "config.h"
 #undef NP2SRV_PIDFILE
 #define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
 


### PR DESCRIPTION
As usual, all build artefacts should go outside of the source tree.