### PR TITLE
server: ignore if host key not found at build time

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -62,14 +62,7 @@ endif()
 
 # set default SSH key
 if (KEYSTORED_KEYS_DIR STREQUAL "none")
-    message(STATUS "Server configuration off, default SSH host key will be used.")
-    # if (EXISTS) succeeds only if the file is readable, we do not care about that
-    execute_process(COMMAND ls "${DEFAULT_HOST_KEY}" RESULT_VARIABLE RET OUTPUT_QUIET ERROR_QUIET)
-    if (NOT RET)
-        message(STATUS "Default host key set to \"${DEFAULT_HOST_KEY}\".")
-    else()
-        message(FATAL_ERROR "Host key \"${DEFAULT_HOST_KEY}\" not found, rerun cmake and set DEFAULT_HOST_KEY manually to point to an RSA SSH key.")
-    endif()
+    message(STATUS "Server configuration off, default SSH host key will be used: \"${DEFAULT_HOST_KEY}\".")
 endif()
 
 # check that lnc2 supports np2srv thread count


### PR DESCRIPTION
If `/etc/ssh/ssh_host_rsa_key` is not found during the cmake config step, there is a fatal error which makes the build fail:

```
-- Server configuration off, default SSH host key will be used.
CMake Error at CMakeLists.txt:71 (message):
  Host key "/etc/ssh/ssh_host_rsa_key" not found, rerun cmake and set
  DEFAULT_HOST_KEY manually to point to an RSA SSH key.
```

`DEFAULT_HOST_KEY` is only a default path used at runtime when no other path is specified. If a file actually exists here, it will not be read during the build (moreover, the default path is only readable by root anyway, and building as root is considered bad).

The machine where the server will run is not necessarily the one where the build is done. If the file is not found at runtime, there will be an explicit error.

Do not check if the file exists at compile time.