### PR TITLE
make auth keys settings accessible for call home

### DIFF
--- a/cli/commands.c
+++ b/cli/commands.c
@@ -1207,7 +1207,9 @@ cmd_auth(const char *arg, char **UNUSED(tmp_config_file))
                 ERROR("auth keys add", "Missing the public key path");
                 return EXIT_FAILURE;
             }
-            if (nc_client_ssh_add_keypair(str, cmd) != EXIT_SUCCESS) {
+
+            if (nc_client_ssh_ch_add_keypair(str, cmd) != EXIT_SUCCESS ||
+                nc_client_ssh_add_keypair(str, cmd) != EXIT_SUCCESS) {
                 ERROR("auth keys add", "Failed to add keys");
                 return EXIT_FAILURE;
             }
@@ -1227,7 +1229,7 @@ cmd_auth(const char *arg, char **UNUSED(tmp_config_file))
             }
 
             i = strtol(cmd, &ptr, 10);
-            if (ptr[0] || nc_client_ssh_del_keypair(i)) {
+            if (ptr[0] || nc_client_ssh_ch_del_keypair(i) || nc_client_ssh_del_keypair(i)) {
                 ERROR("auth keys remove", "Wrong index");
                 return EXIT_FAILURE;
             }

--- a/cli/configuration.c
+++ b/cli/configuration.c
@@ -350,6 +350,7 @@ load_config(void)
                                                 }
                                             }
                                             if (key_pub && key_priv) {
+                                                nc_client_ssh_ch_add_keypair(key_pub, key_priv);
                                                 nc_client_ssh_add_keypair(key_pub, key_priv);
                                             }
                                         }


### PR DESCRIPTION
Hi,
I made some small add-ons in order to get "call home" using netopeer2-cli working with public key authentication. These changes were necessary because the keys added by "auth keys add ..." command were not used for the "call home" ssh connection;  only password / interactive authentication was possible.

Please have a look at it. 

Regards,
Frank