### PR TITLE
SSH key provisioning: followup fixes

### DIFF
--- a/keystored/CMakeLists.txt
+++ b/keystored/CMakeLists.txt
@@ -140,5 +140,10 @@ if (SSH_KEY_INSTALL)
         execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/ssh-key-import.sh)")
 endif()
 
+add_custom_target(install-scripts-ide
+    scripts/model-install.sh
+    scripts/ssh-key-import.sh
+)
+
 # plugins should be installed into sysrepo plugins dir
 install(TARGETS keystored DESTINATION ${SR_PLUGINS_DIR})

--- a/keystored/CMakeLists.txt
+++ b/keystored/CMakeLists.txt
@@ -120,6 +120,15 @@ if (MODEL_INSTALL)
         execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/model-install.sh)")
 endif()
 
+# Use KEYSTORED_DEFER_SSH_KEY=ON to skip automatic key conversion.
+# Some external build/deploy script is then responsible for providing an SSH
+# host key in a PEM format at runtime.
+if (NOT KEYSTORED_DEFER_SSH_KEY)
+    set(KEYSTORED_CHECK_SSH_KEY 1)
+else()
+    set(KEYSTORED_CHECK_SSH_KEY 0)
+endif()
+
 option(SSH_KEY_INSTALL "Enable ssh key import" ON)
 if (SSH_KEY_INSTALL)
     install(CODE "
@@ -127,6 +136,7 @@ if (SSH_KEY_INSTALL)
         set(ENV{CHMOD} ${CHMOD_EXECUTABLE})
         set(ENV{OPENSSL} ${OPENSSL_EXECUTABLE})
         set(ENV{KEYSTORED_KEYS_DIR} ${KEYSTORED_KEYS_DIR})
+        set(ENV{KEYSTORED_CHECK_SSH_KEY} ${KEYSTORED_CHECK_SSH_KEY})
         execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/ssh-key-import.sh)")
 endif()
 

--- a/keystored/scripts/ssh-key-import.sh
+++ b/keystored/scripts/ssh-key-import.sh
@@ -19,10 +19,12 @@ fi
 if [ $KEYSTORED_CHECK_SSH_KEY -eq 0 ]; then
     echo "Warning: Assuming that an external script will provide the SSH key in a PEM format at \"${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem\"."
     $SYSREPOCFG -d startup -i ${STOCK_KEY_CONFIG} ietf-keystore
-elif [ -f /etc/ssh/ssh_host_rsa_key ]; then
+elif [ -r /etc/ssh/ssh_host_rsa_key ]; then
     cp /etc/ssh/ssh_host_rsa_key ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem
     $CHMOD go-rw ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem
     $OPENSSL rsa -pubout -in ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem \
         -out ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pub.pem
     $SYSREPOCFG -d startup -i ${STOCK_KEY_CONFIG} ietf-keystore
+else
+    echo "Warning: Cannot read the SSH hostkey at /etc/ssh/ssh_host_rsa_key, skipping"
 fi

--- a/keystored/scripts/ssh-key-import.sh
+++ b/keystored/scripts/ssh-key-import.sh
@@ -16,7 +16,10 @@ if [ -n "$($SYSREPOCFG -d startup --export ietf-keystore)" ]; then
     exit 0
 fi
 
-if [ -f /etc/ssh/ssh_host_rsa_key ]; then
+if [ $KEYSTORED_CHECK_SSH_KEY -eq 0 ]; then
+    echo "Warning: Assuming that an external script will provide the SSH key in a PEM format at \"${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem\"."
+    $SYSREPOCFG -d startup -i ${STOCK_KEY_CONFIG} ietf-keystore
+elif [ -f /etc/ssh/ssh_host_rsa_key ]; then
     cp /etc/ssh/ssh_host_rsa_key ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem
     $CHMOD go-rw ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem
     $OPENSSL rsa -pubout -in ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem \

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -177,6 +177,10 @@ if (ENABLE_CONFIGURATION)
         execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/model-install.sh)")
 endif()
 
+add_custom_target(install-scripts-ide
+    scripts/model-install.sh
+)
+
 configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "${PROJECT_BINARY_DIR}/config.h" ESCAPE_QUOTES @ONLY)
 include_directories(${PROJECT_BINARY_DIR})
 


### PR DESCRIPTION
Commit f9dafad added a method of overriding the heuristics for checking the existing openssh-style host key. This got accidentally removed in 0970cea. The use case is Buildroot and reducing the amount of stuff which has to run on the target system.