### PR TITLE
Better defaults for listening configuration

### DIFF
--- a/server/stock_config.xml
+++ b/server/stock_config.xml
@@ -1,13 +1,13 @@
 <netconf-server xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-server">
   <listen>
     <endpoint>
-      <name>test_ssh_listen_endpt</name>
+      <name>all-interfaces</name>
       <ssh>
         <address>0.0.0.0</address>
         <port>830</port>
         <host-keys>
           <host-key>
-            <name>test_ssh_listen_key</name>
+            <name>imported SSH key</name>
             <public-key>ssh_host_rsa_key</public-key>
           </host-key>
         </host-keys>


### PR DESCRIPTION
- enable IPv6 sockets (which include also IPv4 addresses on modern
Linux)
- use more descriptive names of the configuration
- nuke the "test" prefixes