### PR TITLE
Add flag to treat SIGHUP/SIGUSR1 as termination

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 option(ENABLE_CONFIGURATION "Enable server configuration" ON)
 set(THREAD_COUNT 5 CACHE STRING "Number of threads accepting new sessions and handling requests")
 set(DEFAULT_HOST_KEY "/etc/ssh/ssh_host_rsa_key" CACHE STRING "Default server host key (used only if configuration is disabled)")
+set(DISABLE_RESTART_SIGNALS 0 CACHE STRING "Set this to 1 to treat SIGHUP and SIGUSR1 as termination signals instead of restart signals")
 
 # set prefix for the PID file
 if (NOT PIDFILE_PREFIX)

--- a/server/config.h.in
+++ b/server/config.h.in
@@ -40,6 +40,13 @@
 #   define NP2SRV_THREAD_COUNT @THREAD_COUNT@
 #endif
 
+/** @brief If set to 0, SIGHUP and SIGUSR1 will attempt to restart the server's main thread.
+  *        If set to 1, SIGHUP and SIGUSR1 are treated as termination signals (like SIGTERM)
+  */
+#ifndef NP2SRV_DISABLE_RESTART_SIGNALS
+#   define NP2SRV_DISABLE_RESTART_SIGNALS @DISABLE_RESTART_SIGNALS@
+#endif
+
 /** @brief availability of pthread_rwlockattr_setkind_np()
  */
 #cmakedefine HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP 1

--- a/server/main.c
+++ b/server/main.c
@@ -203,6 +203,13 @@ signal_handler(int sig)
     static int quit = 0;
 
     switch (sig) {
+    case SIGHUP:
+    case SIGUSR1:
+#if NP2SRV_DISABLE_RESTART_SIGNALS == 0
+        /* restart the process */
+        control = LOOP_RESTART;
+        break;
+#endif
     case SIGINT:
     case SIGTERM:
     case SIGQUIT:
@@ -216,11 +223,6 @@ signal_handler(int sig)
             exit(EXIT_FAILURE);
         }
         control = LOOP_STOP;
-        break;
-    case SIGHUP:
-    case SIGUSR1:
-        /* restart the process */
-        control = LOOP_RESTART;
         break;
 #ifdef DEBUG
     case SIGSEGV:


### PR DESCRIPTION
`netopeer2-server`'s signal handler currently attempts to restart netopeer2-server if it receives `SIGHUP` or `SIGUSR1`. Unfortunately, we've noticed several problems with the server restart mechanism. For example, libssh's thread.c does not properly clean up its state, so netopeer2-server crashes with a segmentation fault when restarting.

This pull request does not attempt to address any of the problems with the server restart mechanism. Instead, it adds an optional configuration flag `DISABLE_RESTART_SIGNALS` that allows us to treat `SIGHUP` and `SIGUSR1` as signals that will _terminate_ the server instead of restarting it. The flag is disabled by default, so the existing behavior remains unchanged.