### PR TITLE
Fix missing identityref module name (fixes #279)

### DIFF
--- a/server/op_generic.c
+++ b/server/op_generic.c
@@ -33,13 +33,18 @@ build_rpc_act_from_output(struct lyd_node *rpc_act, sr_val_t *output, size_t out
 {
     struct lyd_node *node, *iter;
     uint32_t i;
-    char buf[21];
+    char *buf;
+    int alloced;
 
     for (i = 0; i < out_count; ++i) {
         ly_errno = LY_SUCCESS;
-        node = lyd_new_path(rpc_act, np2srv.ly_ctx, output[i].xpath, op_get_srval(np2srv.ly_ctx, &output[i], buf),
+        if (op_get_srval(np2srv.ly_ctx, &output[i], &buf, &alloced)) {
+            return -1;
+        }
+        node = lyd_new_path(rpc_act, np2srv.ly_ctx, output[i].xpath, buf,
                 (output->type == SR_ANYXML_T || output->type == SR_ANYDATA_T) ? LYD_ANYDATA_SXML : 0,
                 LYD_PATH_OPT_UPDATE | LYD_PATH_OPT_OUTPUT);
+        op_get_srval_free(buf, alloced);
         if (ly_errno != LY_SUCCESS) {
             return -1;
         }

--- a/server/operations.h
+++ b/server/operations.h
@@ -114,7 +114,27 @@ int np2srv_sr_get_submodule_schema(sr_session_ctx_t *srs, const char *submodule_
 int np2srv_sr_get_schema(sr_session_ctx_t *srs, const char *module_name, const char *revision,
          const char *submodule_name, sr_schema_format_t format, char **schema_content, struct nc_server_reply **ereply);
 
-char *op_get_srval(struct ly_ctx *ctx, const sr_val_t *value, char *buf);
+/**
+ * @brief Get sr_val_t from communication with sysrepo
+ *
+ * @param[in] ctx Context from which the value is retrieved
+ * @param[in] value The \p val structure
+ *                 path in sr_val_t for specific use.
+ * @param[out] val_buf Store the pointer to the value. If it the responsibility of the caller to deallocate
+ *                the memory. This should be done via op_get_srval_dealloc
+ * @param[out] alloced 1 if memory was allocated, 0 otherwise
+ * @see op_get_srval_dealloc
+ */
+int op_get_srval(struct ly_ctx *ctx, const sr_val_t *value, char **val_buf, int *alloced);
+
+/**
+ * @brief Deallocate memory allocated by op_get_srval
+ *
+ * @param[in] val_buf The pointer to the value
+ * @param[in] alloced 1 if memory was allocated, 0 otherwise
+ * @see op_get_srval
+ */
+void op_get_srval_free(char *val_buf, int alloced);
 
 /**
  * @brief Fill sr_val_t for communication with sysrepo

--- a/server/tests/config.h.in
+++ b/server/tests/config.h.in
@@ -146,6 +146,8 @@ __wrap_sr_get_schema(sr_session_ctx_t *session, const char *module_name, const c
         fd = open(TESTS_DIR "/files/test-feature-b.yin", O_RDONLY);
     } else if (!strcmp(module_name, "test-feature-c")) {
         fd = open(TESTS_DIR "/files/test-feature-c.yin", O_RDONLY);
+    } else if (!strcmp(module_name, "simplified-melt")) {
+        fd = open(TESTS_DIR "/files/simplified-melt.yin", O_RDONLY);
     } else {
         return SR_ERR_NOT_FOUND;
     }

--- a/server/tests/files/simplified-melt.yin
+++ b/server/tests/files/simplified-melt.yin
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="simplified-melt"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:smelt="urn:ietf:params:xml:ns:yang:simplified-melt">
+  <namespace uri="urn:ietf:params:xml:ns:yang:simplified-melt"/>
+  <prefix value="smelt"/>
+  <identity name="measurement-class"/>
+  <identity name="melt-cdcr">
+    <base name="measurement-class"/>
+  </identity>
+  <container name="melt">
+    <list name="pmd-profile">
+      <key value="name"/>
+      <leaf name="name">
+        <type name="string"/>
+      </leaf>
+      <leaf-list name="measurement-class">
+        <type name="identityref">
+          <base name="measurement-class"/>
+        </type>
+        <ordered-by value="user"/>
+      </leaf-list>
+    </list>
+  </container>
+</module>

--- a/server/tests/test_edit_get_config.c
+++ b/server/tests/test_edit_get_config.c
@@ -320,10 +320,7 @@ __wrap_sr_set_item(sr_session_ctx_t *session, const char *xpath, const sr_val_t 
     case SR_CONTAINER_PRESENCE_T:
     case SR_LEAF_EMPTY_T:
         ly_errno = LY_SUCCESS;
-        rc = op_get_srval(np2srv.ly_ctx, (sr_val_t *)value, &buf, &alloced);
-        assert_int_equal(0, rc);
-        lyd_new_path(data, np2srv.ly_ctx, xpath, buf, 0, opt);
-        op_get_srval_free(buf, alloced);
+        lyd_new_path(data, np2srv.ly_ctx, xpath, NULL, 0, opt);
         if ((ly_errno == LY_EVALID) && (ly_vecode(np2srv.ly_ctx) == LYVE_PATH_EXISTS)) {
             return SR_ERR_DATA_EXISTS;
         }
@@ -331,7 +328,11 @@ __wrap_sr_set_item(sr_session_ctx_t *session, const char *xpath, const sr_val_t 
         break;
     default:
         ly_errno = LY_SUCCESS;
-        lyd_new_path(data, np2srv.ly_ctx, xpath, op_get_srval(np2srv.ly_ctx, (sr_val_t *)value, buf), 0, opt);
+        
+        rc = op_get_srval(np2srv.ly_ctx, (sr_val_t *)value, &buf, &alloced);
+        assert_int_equal(0, rc);
+        lyd_new_path(data, np2srv.ly_ctx, xpath, buf, 0, opt);
+        op_get_srval_free(buf, alloced);
         if ((ly_errno == LY_EVALID) && (ly_vecode(np2srv.ly_ctx) == LYVE_PATH_EXISTS)) {
             return SR_ERR_DATA_EXISTS;
         }

--- a/server/tests/test_edit_get_config.c
+++ b/server/tests/test_edit_get_config.c
@@ -72,7 +72,7 @@ __wrap_sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t 
 {
     (void)session;
 
-    *schema_cnt = 7;
+    *schema_cnt = 8;
 
     *schemas = calloc(*schema_cnt, sizeof **schemas);
 
@@ -136,6 +136,13 @@ __wrap_sr_list_schemas(sr_session_ctx_t *session, sr_schema_t **schemas, size_t 
     (*schemas)[6].enabled_features[0] = strdup("test-feature-a");
     (*schemas)[6].enabled_feature_cnt = 1;
     (*schemas)[6].installed = 1;
+
+    (*schemas)[7].module_name = strdup("simplified-melt");
+    (*schemas)[7].ns = strdup("urn:ietf:params:xml:ns:simplified-melt");
+    (*schemas)[7].prefix = strdup("smelt");
+    (*schemas)[7].revision.revision = strdup("2018-06-13");
+    (*schemas)[7].revision.file_path_yin = strdup(TESTS_DIR"/files/simplified-melt.yin");
+    (*schemas)[7].installed = 1;
 
     return SR_ERR_OK;
 }
@@ -240,7 +247,7 @@ __wrap_sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t
     size_t ietf_interfaces_xpath_len = strlen(ietf_interfaces_xpath);
     (void)session;
 
-    if (!strncmp(xpath, ietf_interfaces_xpath, ietf_interfaces_xpath_len) || !strcmp(xpath, "/test-feature-c:*//.")) {
+    if (!strncmp(xpath, ietf_interfaces_xpath, ietf_interfaces_xpath_len) || !strcmp(xpath, "/test-feature-c:*//.") || !strcmp(xpath, "/simplified-melt:*//.")) {
         if (!ietf_if_set) {
             ietf_if_set = lyd_find_path(data, xpath);
         }
@@ -252,6 +259,20 @@ __wrap_sr_get_item_next(sr_session_ctx_t *session, sr_val_iter_t *iter, sr_val_t
         }
 
         path = lyd_path(ietf_if_set->set.d[0]);
+
+        /* Copied from sysrepo rp_dt_create_xpath_for_node() */
+        
+        /* remove leaf-list predicate */
+        if (LYS_LEAFLIST & ietf_if_set->set.d[0]->schema->nodetype) {
+           char *leaf_list_name = strstr(path, "[.='");
+           if (NULL != leaf_list_name) {
+               *leaf_list_name = 0;
+           } else if (NULL != (leaf_list_name = strstr(path, "[.=\""))) {
+               *leaf_list_name = 0;
+           }
+        }
+        /* End copy */
+        
         *value = calloc(1, sizeof **value);
         op_set_srval(ietf_if_set->set.d[0], path, 1, *value, NULL);
         (*value)->dflt = ietf_if_set->set.d[0]->dflt;
@@ -281,8 +302,10 @@ int
 __wrap_sr_set_item(sr_session_ctx_t *session, const char *xpath, const sr_val_t *value, const sr_edit_options_t opts)
 {
     (void)session;
-    char buf[128];
+    char *buf;
+    int alloced;
     int opt = 0;
+    int rc;
 
     if (opts & SR_EDIT_NON_RECURSIVE) {
         opt |= LYD_PATH_OPT_NOPARENT;
@@ -297,7 +320,10 @@ __wrap_sr_set_item(sr_session_ctx_t *session, const char *xpath, const sr_val_t 
     case SR_CONTAINER_PRESENCE_T:
     case SR_LEAF_EMPTY_T:
         ly_errno = LY_SUCCESS;
-        lyd_new_path(data, np2srv.ly_ctx, xpath, NULL, 0, opt);
+        rc = op_get_srval(np2srv.ly_ctx, (sr_val_t *)value, &buf, &alloced);
+        assert_int_equal(0, rc);
+        lyd_new_path(data, np2srv.ly_ctx, xpath, buf, 0, opt);
+        op_get_srval_free(buf, alloced);
         if ((ly_errno == LY_EVALID) && (ly_vecode(np2srv.ly_ctx) == LYVE_PATH_EXISTS)) {
             return SR_ERR_DATA_EXISTS;
         }
@@ -1482,6 +1508,144 @@ test_edit_merge2(void **state)
 }
 
 static void
+test_edit_merge3(void **state)
+{
+    (void)state; /* unused */
+    const char *get_config_rpc =
+    "<rpc msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<get-config>"
+            "<source>"
+                "<running/>"
+            "</source>"
+        "</get-config>"
+    "</rpc>";
+    const char *get_config_rpl =
+    "<rpc-reply msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<data xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+"<interfaces xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\">"
+  "<interface>"
+    "<name>iface2</name>"
+    "<description>iface2 dsc</description>"
+    "<type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:softwareLoopback</type>"
+    "<enabled>false</enabled>"
+    "<link-up-down-trap-enable>disabled</link-up-down-trap-enable>"
+    "<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<address>"
+        "<ip>10.0.0.5</ip>"
+        "<netmask>255.0.0.0</netmask>"
+      "</address>"
+      "<address>"
+        "<ip>172.0.0.5</ip>"
+        "<prefix-length>16</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>10.0.0.1</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:fa</link-layer-address>"
+      "</neighbor>"
+    "</ipv4>"
+    "<ipv6 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<address>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:5</ip>"
+        "<prefix-length>64</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:1</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:fa</link-layer-address>"
+      "</neighbor>"
+      "<dup-addr-detect-transmits>100</dup-addr-detect-transmits>"
+      "<autoconf>"
+        "<create-global-addresses>true</create-global-addresses>"
+        "<create-temporary-addresses>false</create-temporary-addresses>"
+        "<temporary-valid-lifetime>600</temporary-valid-lifetime>"
+        "<temporary-preferred-lifetime>300</temporary-preferred-lifetime>"
+      "</autoconf>"
+    "</ipv6>"
+  "</interface>"
+  "<interface>"
+    "<name>iface1</name>"
+    "<description>iface1 dsc</description>"
+    "<type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>"
+    "<enabled>true</enabled>"
+    "<ipv4 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<enabled>true</enabled>"
+      "<forwarding>true</forwarding>"
+      "<mtu>68</mtu>"
+      "<address>"
+        "<ip>10.0.0.1</ip>"
+        "<netmask>255.0.0.0</netmask>"
+      "</address>"
+      "<address>"
+        "<ip>172.0.0.1</ip>"
+        "<prefix-length>16</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>10.0.0.2</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:f0</link-layer-address>"
+      "</neighbor>"
+    "</ipv4>"
+    "<ipv6 xmlns=\"urn:ietf:params:xml:ns:yang:ietf-ip\">"
+      "<enabled>true</enabled>"
+      "<forwarding>false</forwarding>"
+      "<mtu>1280</mtu>"
+      "<address>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:1</ip>"
+        "<prefix-length>64</prefix-length>"
+      "</address>"
+      "<neighbor>"
+        "<ip>2001:abcd:ef01:2345:6789:0:1:2</ip>"
+        "<link-layer-address>01:34:56:78:9a:bc:de:f0</link-layer-address>"
+      "</neighbor>"
+      "<dup-addr-detect-transmits>52</dup-addr-detect-transmits>"
+      "<autoconf>"
+        "<create-global-addresses>true</create-global-addresses>"
+        "<create-temporary-addresses>false</create-temporary-addresses>"
+        "<temporary-valid-lifetime>600</temporary-valid-lifetime>"
+        "<temporary-preferred-lifetime>300</temporary-preferred-lifetime>"
+      "</autoconf>"
+    "</ipv6>"
+    "<link-up-down-trap-enable>disabled</link-up-down-trap-enable>"
+  "</interface>"
+"</interfaces>"
+"<test-container xmlns=\"urn:ietf:params:xml:ns:yang:test-feature-c\">"
+  "<test-leaf>green</test-leaf>"
+"</test-container>"
+"<melt xmlns=\"urn:ietf:params:xml:ns:yang:simplified-melt\">"
+  "<pmd-profile>"
+    "<name>melt-pmd-01</name>"
+    "<measurement-class>melt-cdcr</measurement-class>"
+  "</pmd-profile>"
+"</melt>"
+        "</data>"
+    "</rpc-reply>";   
+    const char *edit_rpc =
+    "<rpc msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<edit-config>"
+            "<target>"
+                "<running/>"
+            "</target>"
+            "<config>"
+"<melt xmlns=\"urn:ietf:params:xml:ns:yang:simplified-melt\">"
+  "<pmd-profile>"
+    "<name>melt-pmd-01</name>"
+    "<measurement-class>melt-cdcr</measurement-class>"
+  "</pmd-profile>"
+"</melt>"
+            "</config>"
+        "</edit-config>"
+    "</rpc>";
+    const char *edit_rpl =
+    "<rpc-reply msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"
+        "<ok/>"
+    "</rpc-reply>";
+
+    test_write(p_out, edit_rpc, __LINE__);
+    test_read(p_in, edit_rpl, __LINE__);
+
+    test_write(p_out, get_config_rpc, __LINE__);
+    test_read(p_in, get_config_rpl, __LINE__);
+}
+
+static void
 test_get_filter(void **state)
 {
     (void)state; /* unused */
@@ -1539,6 +1703,7 @@ main(void)
                     cmocka_unit_test(test_edit_create3),
                     cmocka_unit_test(test_edit_merge1),
                     cmocka_unit_test(test_edit_merge2),
+                    cmocka_unit_test(test_edit_merge3),
                     cmocka_unit_test(test_get_filter),
                     cmocka_unit_test_teardown(test_startstop, np_stop),
     };


### PR DESCRIPTION
Changed op_get_srval() so that it prepends the module name to the identityref value. This changes the API since op_get_srval() needs to allocate memory in this case. Therefore, a new API function was also added to free this memory, op_get_srval_free().

A new cmocka test was added that reproduces the missing identityref module error.