### PR TITLE
Updating keystored logic to account for module name in addtion to identityref value

### DIFF
--- a/keystored/keystored.c
+++ b/keystored/keystored.c
@@ -298,6 +298,7 @@ ks_privkey_gen_cb(const char *UNUSED(xpath), const sr_node_t *input, const size_
     pid_t pid;
     int ret = SR_ERR_OK, status;
     char *priv_path = NULL, *pub_path = NULL, len_arg[27];
+    char *algorithm;
 
     if ((input_cnt < 2) || (input[0].type != SR_STRING_T) || (input[1].type != SR_IDENTITYREF_T)
             || ((input_cnt == 3) && (input[2].type != SR_UINT32_T))) {
@@ -306,7 +307,15 @@ ks_privkey_gen_cb(const char *UNUSED(xpath), const sr_node_t *input, const size_
         goto cleanup;
     }
 
-    if (strcmp(input[1].data.string_val, "rsa")) {
+    /* Get algorithm, skipping module name (if present) */
+    algorithm = strchr(input[1].data.string_val, ':');
+    if (!algorithm) {
+        algorithm = input[1].data.string_val;
+    } else {
+        algorithm++;
+    }
+
+    if (strcmp(algorithm, "rsa")) {
         SRP_LOG_ERR_MSG("Generating EC private keys not supported yet.");
         ret = SR_ERR_UNSUPPORTED;
         goto cleanup;


### PR DESCRIPTION
As of https://github.com/sysrepo/sysrepo/pull/1177, we started seeing errors in sysrepo-plugin when setting the ietf-keystore algorithm parameter. 

Example snippet:
```<action xmlns="urn:ietf:params:xml:ns:yang:1">
  <keystore xmlns="urn:ietf:params:xml:ns:yang:ietf-keystore">
    <private-keys>
      <generate-private-key>
        <name>nc-server</name>
        <algorithm xmlns:ks="urn:ietf:params:xml:ns:yang:ietf-keystore">ks:rsa</algorithm>
      </generate-private-key>
    </private-keys>
  </keystore>
</action>
```
Error:
```
Generating EC private keys not supported yet.
```
After investigation, we found that after the change in https://github.com/sysrepo/sysrepo/pull/1177, sysrepo is now passing both the module name and the identityref value to sysrepo-plugin and the current code is expecting just the identityref value.

This PR should fix that behavior.