### PR TITLE
Fix issue with actions from augments

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif()
 
-set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra")
+set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu11")
 set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG   "-g -O0 -DDEBUG")
 

--- a/server/main.c
+++ b/server/main.c
@@ -267,7 +267,7 @@ np2srv_module_assign_clbs(const struct lys_module *mod)
         return EXIT_SUCCESS;
     }
     np2srv_node_assign_clbs(mod->data);
-    for(uint8_t i = 0; i < mod->augment_size; ++i) {
+    for (uint8_t i = 0; i < mod->augment_size; ++i) {
         struct lys_node *target = mod->augment[i].target;
         if (!strcmp(target->module->name, "ietf-netconf-monitoring") || !strcmp(target->module->name, "ietf-netconf")) {
             continue;

--- a/server/main.c
+++ b/server/main.c
@@ -222,18 +222,13 @@ signal_handler(int sig)
     }
 }
 
-static int
-np2srv_module_assign_clbs(const struct lys_module *mod)
+static void
+np2srv_node_assign_clbs(struct lys_node *start)
 {
     struct lys_node *snode, *next;
 
-    if (!strcmp(mod->name, "ietf-netconf-monitoring") || !strcmp(mod->name, "ietf-netconf")) {
-        /* skip it, use internal implementations from libnetconf2 */
-        return EXIT_SUCCESS;
-    }
-
     /* set RPC and Notifications callbacks */
-    LY_TREE_DFS_BEGIN(mod->data, next, snode) {
+    LY_TREE_DFS_BEGIN(start, next, snode) {
         if (snode->nodetype & (LYS_RPC | LYS_ACTION)) {
             nc_set_rpc_callback(snode, op_generic);
             goto dfs_nextsibling;
@@ -260,6 +255,24 @@ dfs_nextsibling:
             }
             next = snode->next;
         }
+    }
+
+}
+
+static int
+np2srv_module_assign_clbs(const struct lys_module *mod)
+{
+    if (!strcmp(mod->name, "ietf-netconf-monitoring") || !strcmp(mod->name, "ietf-netconf")) {
+        /* skip it, use internal implementations from libnetconf2 */
+        return EXIT_SUCCESS;
+    }
+    np2srv_node_assign_clbs(mod->data);
+    for(uint8_t i = 0; i < mod->augment_size; ++i) {
+        struct lys_node *target = mod->augment[i].target;
+        if (!strcmp(target->module->name, "ietf-netconf-monitoring") || !strcmp(target->module->name, "ietf-netconf")) {
+            continue;
+        }
+        np2srv_node_assign_clbs(target);
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
This pull request fixes an issue with actions from augments. Before this change, an action added by an augment would always be treated as "unimplemented", even if there is a subscriber for it downstream of sysrepo.

We've written integration tests that demonstrate the problem. The fix here will allow the failing test cases (see [CI results], lines 7278-7279 and [test source code]) to pass. (We did not add a unit test for this, as main.c isn't being tested in that context right now.)

[CI results]: https://travis-ci.org/ADTRAN/netopeer2-integration-tests/builds/413288159#L7278
[test source code]: https://github.com/ADTRAN/netopeer2-integration-tests/blob/master/tests/test_action.py#L58