### PR TITLE
Cache ly_ctx_info to improve get performance

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -36,6 +36,11 @@ option(ENABLE_CONFIGURATION "Enable server configuration" ON)
 set(THREAD_COUNT 5 CACHE STRING "Number of threads accepting new sessions and handling requests")
 set(DEFAULT_HOST_KEY "/etc/ssh/ssh_host_rsa_key" CACHE STRING "Default server host key (used only if configuration is disabled)")
 
+option(ENABLE_LY_CTX_INFO_CACHE "Enable caching the ly_ctx_info() result; reduces processing at the cost of increased memory usage." ON)
+if(ENABLE_LY_CTX_INFO_CACHE)
+    set(NP2SRV_ENABLED_LY_CTX_INFO_CACHE 1)
+endif()
+
 # set prefix for the PID file
 if (NOT PIDFILE_PREFIX)
     set(PIDFILE_PREFIX "/var/run")

--- a/server/common.h
+++ b/server/common.h
@@ -49,6 +49,7 @@ struct np2srv {
     pthread_t workers[NP2SRV_THREAD_COUNT]; /**< worker threads handling sessions */
 
     struct ly_ctx *ly_ctx;         /**< libyang's context */
+    struct lyd_node *ly_ctx_info_cache; /** < a cache of calling ly_ctx_info on the ly_ctx */
     pthread_rwlock_t ly_ctx_lock;  /**< libyang's context rwlock */
 };
 extern struct np2srv np2srv;

--- a/server/common.h
+++ b/server/common.h
@@ -49,7 +49,10 @@ struct np2srv {
     pthread_t workers[NP2SRV_THREAD_COUNT]; /**< worker threads handling sessions */
 
     struct ly_ctx *ly_ctx;         /**< libyang's context */
-    struct lyd_node *ly_ctx_info_cache; /** < a cache of calling ly_ctx_info on the ly_ctx */
+#ifdef NP2SRV_ENABLED_LY_CTX_INFO_CACHE
+    uint16_t cached_ly_ctx_module_set_id; /**< module-set-id at the time ly_ctx_info was last cached */
+    struct lyd_node *ly_ctx_info_cache; /**< a cache of calling ly_ctx_info on the ly_ctx */
+#endif
     pthread_rwlock_t ly_ctx_lock;  /**< libyang's context rwlock */
 };
 extern struct np2srv np2srv;

--- a/server/config.h.in
+++ b/server/config.h.in
@@ -52,4 +52,8 @@
  */
 #define NP2SRV_SR_LOCKED_RETRIES 3
 
+/** @brief Enable caching the ly_ctx_info() result
+ */
+#cmakedefine NP2SRV_ENABLED_LY_CTX_INFO_CACHE
+
 #endif /* NP2SRV_CONFIG_H_ */


### PR DESCRIPTION
Fixes #304

This change results in a 3x to 4x speedup for unfiltered get requests (and for requests for the ietf-yang-library contents).

We now cache the results of the `ly_ctx_info(np2srv.ly_ctx)` call and save it in the `np2srv` global, to avoid repeating the call when it would just return the same data.

We update the cached value when necessary, namely, when a module or feature is changed.

Because the contents of the cache should change relatively infrequently, it seems worth it to pay the cost early instead of for every request.