### PR TITLE
Test model modification to add default to leaf

### DIFF
--- a/server/tests/files/test-feature-c.yin
+++ b/server/tests/files/test-feature-c.yin
@@ -23,6 +23,7 @@
     <if-feature name="test-feature-c"/>
     <leaf name="test-leaf">
       <type name="string"/>
+      <default value="foo"/>
     </leaf>
   </container>
 </module>


### PR DESCRIPTION
This changes a test model to add a default to a leaf inside a container. The change will cause `test_edit_delete1()` in `test_edit_get_config` to fail due to the unexpected empty `test-container`. This failure demonstrates #316 . (The test will fail until until the issue in #316 is resolved.)