### PR TITLE
Fix nested containers with default children

### DIFF
--- a/server/tests/files/test-feature-c.yin
+++ b/server/tests/files/test-feature-c.yin
@@ -25,5 +25,19 @@
       <type name="string"/>
       <default value="foo"/>
     </leaf>
+    <container name="nested-container">
+      <container name="inner-container-1">
+        <leaf name="inner-leaf">
+          <type name="string"/>
+          <default value="foo"/>
+        </leaf>
+      </container>
+      <container name="inner-container-2">
+        <leaf name="inner-leaf">
+          <type name="string"/>
+          <default value="foo"/>
+        </leaf>
+      </container>
+    </container>
   </container>
 </module>


### PR DESCRIPTION
Fixes #316.

The previous fix in a9844e2 unfortunately only fixes the case where the container with the default child(ren) is at the top level of the tree. When there are containers with default child(ren) nested inside of other containers, all of the outer containers still do not have their default flag set correctly.

This is because when `lyd_insert_common()` re-evaluates the default flag, it correctly updates not only the direct parent but also all more distant ancestors:

```
    if (clrdflt) {
        /* remove the dflt flag from parents */
        for (iter = parent; iter && iter->dflt; iter = iter->parent) {
            iter->dflt = 0;
        }
    }
```

This commit uses the same idea as a9844e2, but instead of saving only the immediate parent's `dflt` flag, it counts the number of non-default ancestors. After any node is inserted, it then re-walks the parents, resetting the default flag up to the correct depth.

A better solution would probably be to modify `lyd_new_leaf()` and `lyd_new()` to take a `dflt` parameter, which could be passed from `op_sr2ly()`, and then _libyang_ would take care of keeping the default flags correct. But that would mean a _libyang_ public API change.

This commit also modifies the test model again (compare #317) to have multiple nested children, and verifies the new fix.