### PR TITLE
Provide the other certs from the server's cert chain

### DIFF
--- a/server/ietf_keystore.c
+++ b/server/ietf_keystore.c
@@ -102,6 +102,57 @@ np_server_cert_clb(const char *name, void *UNUSED(user_data), char **UNUSED(cert
 }
 
 int
+np_server_cert_chain_clb(const char *name, void *UNUSED(user_data), char ***UNUSED(cert_paths), int *UNUSED(cert_path_count),
+                         char ***cert_data, int *cert_data_count)
+{
+    int ret;
+    char *path;
+    sr_val_t *sr_certs;
+    size_t sr_cert_count, i, used_count;
+
+    ret = asprintf(&path, "/ietf-keystore:keystore/private-keys/private-key/certificate-chains/"
+                   "certificate-chain[name='%s']/certificate", name);
+    if (ret == -1) {
+        EMEM;
+        return 1;
+    }
+
+    if (np2srv.sr_sess.ds != SR_DS_RUNNING) {
+        if (np2srv_sr_session_switch_ds(np2srv.sr_sess.srs, SR_DS_RUNNING, NULL)) {
+            free(path);
+            return 1;
+        }
+        np2srv.sr_sess.ds = SR_DS_RUNNING;
+    }
+
+    /* Refresh the session to prevent sysrepo returning cached data */
+    if (np2srv_sr_session_refresh(np2srv.sr_sess.srs, NULL)) {
+	    ERR("%s:%d Failed session refresh", __func__, __LINE__);
+	    free(path);
+	    return 1;
+    }
+
+    if (np2srv_sr_get_items(np2srv.sr_sess.srs, path, &sr_certs, &sr_cert_count, NULL)) {
+        free(path);
+        return 1;
+    }
+    free(path);
+
+    /* Ignore the first cert since it's already loaded */
+    if (sr_cert_count > 1) {
+        used_count = sr_cert_count - 1;
+        *cert_data = calloc(used_count, sizeof **cert_data);
+        for (i = 0; i < used_count; ++i) {
+            (*cert_data)[i] = strdup(sr_certs[i + 1].data.binary_val);
+        }
+        *cert_data_count = used_count;
+    }
+
+    sr_free_values(sr_certs, sr_cert_count);
+    return 0;
+}
+
+int
 np_trusted_cert_list_clb(const char *name, void *UNUSED(user_data), char ***UNUSED(cert_paths), int *UNUSED(cert_path_count),
                          char ***cert_data, int *cert_data_count)
 {

--- a/server/ietf_keystore.h
+++ b/server/ietf_keystore.h
@@ -20,6 +20,9 @@ int np_hostkey_clb(const char *name, void *user_data, char **privkey_path, char 
 int np_server_cert_clb(const char *name, void *user_data, char **cert_path, char **cert_data, char **privkey_path,
                        char **privkey_data, int *privkey_data_rsa);
 
+int np_server_cert_chain_clb(const char *name, void *user_data, char ***cert_paths, int *cert_path_count,
+                             char ***cert_data, int *cert_data_count);
+
 int np_trusted_cert_list_clb(const char *name, void *user_data, char ***cert_paths, int *cert_path_count,
                              char ***cert_data, int *cert_data_count);
 

--- a/server/ietf_netconf_server.c
+++ b/server/ietf_netconf_server.c
@@ -1241,6 +1241,7 @@ ietf_netconf_server_init(const struct lys_module *module)
     nc_server_ssh_set_hostkey_clb(np_hostkey_clb, NULL, NULL);
 #ifdef NC_ENABLED_TLS
     nc_server_tls_set_server_cert_clb(np_server_cert_clb, NULL, NULL);
+    nc_server_tls_set_server_cert_chain_clb(np_server_cert_chain_clb, NULL, NULL);
     nc_server_tls_set_trusted_cert_list_clb(np_trusted_cert_list_clb, NULL, NULL);
 #endif
 


### PR DESCRIPTION
This commit from @jwwilcox, together with a corresponding commit to _libnetconf2_, fixes the TLS connection scenario in which the server's certificate has been signed by an intermediate CA, but the client only has the root CA available locally. In this case, the client will reject the connection attempt, because it does not know about the intermediate CA.

This change adds an optional callback so that the server can supply the missing certificate. The changes in _libnetconf2_ will use the certificates retrieved from this callback to allow the server's TLS context to automatically provide the intermediate certificate(s) to the client.

This scenario is demonstrated in the integration test `test_tls_client_missing_server_intermediate()` in [ADTRAN:netopeer2-integration-tests](https://github.com/ADTRAN/netopeer2-integration-tests/blob/master/tests/test_tls.py#L73). The changes here, together with the corresponding commit in _libnetconf2_, will allow [the currently failing test case](https://travis-ci.org/ADTRAN/netopeer2-integration-tests/jobs/420293391#L7434) to pass.