### PR TITLE
Fix multi-schema filtered get

### DIFF
--- a/server/operations.c
+++ b/server/operations.c
@@ -2873,6 +2873,14 @@ op_sr2ly_get_cache_parent(const char *xpath, struct sr2ly_cache *cache, struct l
             } else {
                 /* top-level node */
                 cache->items[cache->used - 1].node = lyd_new(NULL, module, cache->items[cache->used - 1].name);
+
+                /* If root already contains a data tree, insert this new top-level node */
+                if (root && cache->items[cache->used - 1].node) {
+                    if (lyd_insert_after(root->prev, cache->items[cache->used - 1].node)) {
+                        ly_set_free(set);
+                        return -1;
+                    }
+                }
             }
             if (!cache->items[cache->used - 1].node) {
                 ly_set_free(set);


### PR DESCRIPTION
This commit fixes the use case for a `get` or `get-config` with a subtree filter containing nodes from more than one schema. This scenario worked correctly in older commits, but was broken by the optimizations in 6ab0617.

The problem was that if there was a `root` tree already populated when `op_sr2ly()` was called, `op_sr2ly()` would correctly construct a new subtree with the requested data, but the subtree would never be attached to the existing `root` tree, and was essentially orphaned. Only the first tree connected to `root` would ever be returned.

I fixed this by adding a call to `lyd_insert_after()` when a new top-level node was created but there was already data in `root`.

This commit includes a test case that demonstrates the problem. The test case will pass in commits prior to 6ab0617, fail in 6ab0617, and then pass again with the code changes here.