### PR TITLE
add support for unix socket transport

### DIFF
--- a/server/config.h.in
+++ b/server/config.h.in
@@ -24,6 +24,12 @@
  */
 #define NP2SRV_PIDFILE "@PIDFILE_PREFIX@/netopeer2-server.pid"
 
+/** @brief Netopeer2 Server UNIX socket file path
+ * The default path /var/run/netopeer2-server.sock follows
+ * the Filesystem Hierarchy Standard
+ */
+#define NP2SRV_UNIX_SOCKFILE "@PIDFILE_PREFIX@/netopeer2-server.sock"
+
 /** @brief Netopeer2 Server SSH default RSA host key path
  */
 #define NP2SRV_HOST_KEY "@DEFAULT_HOST_KEY@"

--- a/server/tests/config.h.in
+++ b/server/tests/config.h.in
@@ -47,6 +47,9 @@ struct nc_session {
             int in;              /**< input file descriptor */
             int out;             /**< output file descriptor */
         } fd;                    /**< NC_TI_FD transport implementation structure */
+        struct {
+            int sock;            /**< socket file descriptor */
+        } unixsock;              /**< NC_TI_UNIX transport implementation structure */
 #ifdef NC_ENABLED_SSH
         struct {
             void *channel;
@@ -63,6 +66,7 @@ struct nc_session {
     const char *username;
     const char *host;
     uint16_t port;
+    const char *path;              /**< socket path in case of unix socket */
 
     /* other */
     struct ly_ctx *ctx;            /**< libyang context of the session */


### PR DESCRIPTION
In addition to SSH and TLS transport, add the support for UNIX
socket.
Related with this pull request in libnetconf2: https://github.com/CESNET/libnetconf2/pull/123

This pull request contains one patch for the server and one for the cli.
