### PR TITLE
Application receive information from which netconf client (session-id…) specific rpc has been sent.

### DIFF
--- a/server/op_generic.c
+++ b/server/op_generic.c
@@ -170,9 +170,9 @@ op_generic(struct lyd_node *rpc, struct nc_session *ncs)
     }
 
     if (!act) {
-        rc = np2srv_sr_rpc_send(sessions->srs, rpc_xpath, input, in_idx, &output, &out_count, &ereply);
+        rc = np2srv_sr_rpc_send(sessions, rpc_xpath, input, in_idx, &output, &out_count, &ereply);
     } else {
-        rc = np2srv_sr_action_send(sessions->srs, rpc_xpath, input, in_idx, &output, &out_count, &ereply);
+        rc = np2srv_sr_action_send(sessions, rpc_xpath, input, in_idx, &output, &out_count, &ereply);
     }
     if (rc) {
         goto finish;

--- a/server/operations.h
+++ b/server/operations.h
@@ -76,9 +76,9 @@ int np2srv_sr_get_items_iter(sr_session_ctx_t *srs, const char *xpath, sr_val_it
 int np2srv_sr_get_item_next(sr_session_ctx_t *srs, sr_val_iter_t *iter, sr_val_t **value, struct nc_server_reply **ereply);
 int np2srv_sr_move_item(sr_session_ctx_t *srs, const char *xpath, const sr_move_position_t position,
         const char *relative_item, struct nc_server_reply **ereply);
-int np2srv_sr_rpc_send(sr_session_ctx_t *srs, const char *xpath, const sr_val_t *input,  const size_t input_cnt,
+int np2srv_sr_rpc_send(struct np2_sessions *srs, const char *xpath, const sr_val_t *input,  const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, struct nc_server_reply **ereply);
-int np2srv_sr_action_send(sr_session_ctx_t *srs, const char *xpath, const sr_val_t *input,  const size_t input_cnt,
+int np2srv_sr_action_send(struct np2_sessions *srs, const char *xpath, const sr_val_t *input,  const size_t input_cnt,
         sr_val_t **output, size_t *output_cnt, struct nc_server_reply **ereply);
 int np2srv_sr_check_exec_permission(sr_session_ctx_t *srs, const char *xpath, struct nc_server_reply **ereply);
 int np2srv_sr_module_change_subscribe(sr_session_ctx_t *srs, const char *module_name, sr_module_change_cb callback,


### PR DESCRIPTION
**Description**
Extended _rpc_cb_ with parameter _netconf_id._ This value is set in Netopeer2-server. In the case of unknown netconf id, this parameter should be 0.

**Test case**
Manual tests.

**Closure**
Netopeer2 #363