### PR TITLE
Fix docker run without TTY in automation environments

### DIFF
--- a/server/integration-tests/Makefile
+++ b/server/integration-tests/Makefile
@@ -1,6 +1,6 @@
 DOCKER_NAME := netopeer2-integration-test-env
 INTEGRATION_TEST_DIR ?= $(shell pwd)
-DOCKER_RUN := docker run -it --rm -v $(INTEGRATION_TEST_DIR):/local -v $(INTEGRATION_TEST_DIR)/build/log:/var/log -w /local/tests --privileged $(DOCKER_NAME)
+DOCKER_RUN := if [ -t 1 ] ; then IS_TTY=t ; fi ; docker run -i$$IS_TTY --rm -v $(INTEGRATION_TEST_DIR):/local -v $(INTEGRATION_TEST_DIR)/build/log:/var/log -w /local/tests --privileged $(DOCKER_NAME)
 
 PYTEST_ARGS ?= -x
 


### PR DESCRIPTION
We had an issue where some of our automation environments could not execute the integration tests with docker run with the -t command, since it was not a TTY. So we have changed it to check if the environment is a TTY and if it is not then it will execute without it. 