### PR TITLE
close memory leak (test case + solution)

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -1772,6 +1772,11 @@ cleanup:
         sr_unsubscribe(np2srv.sr_sess.srs, np2srv.sr_subscr);
     }
 
+    /* close all open sessions */
+    while (nc_ps_session_count(np2srv.nc_ps)!=0) {
+        np2srv_del_session_clb(nc_ps_get_session(np2srv.nc_ps,0));
+    }
+
     /* libnetconf2 cleanup */
     if (np2srv.nc_ps) {
         nc_ps_clear(np2srv.nc_ps, 1, free_ds);

--- a/server/tests/test_kill.c
+++ b/server/tests/test_kill.c
@@ -36,7 +36,7 @@
 
 ATOMIC_T initialized;
 int pipes[4][2], p_in, p_out;
-ATOMIC_UINT32_T num_sessions = 0;
+ATOMIC_T num_sessions = 0;
 
 /*
  * SYSREPO WRAPPER FUNCTIONS
@@ -280,7 +280,7 @@ np_stop(void **state)
     close(pipes[3][1]);
 
     assert_int_equal(nc_ps_session_count(np2srv.nc_ps), 0);
-    assert_int_equal(num_sessions, 0);
+    assert_int_equal(ATOMIC_LOAD(num_sessions), 0);
 
     return ret;
 }
@@ -289,7 +289,7 @@ static void
 test_kill(void **state)
 {
     assert_int_equal(nc_ps_session_count(np2srv.nc_ps), 2);
-    assert_int_equal(num_sessions, 2);
+    assert_int_equal(ATOMIC_LOAD(num_sessions), 2);
 
     (void)state; /* unused */
     const char *close_session_rpc = "<rpc msgid=\"1\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"><kill-session><session-id>2</session-id></kill-session></rpc>";
@@ -299,7 +299,7 @@ test_kill(void **state)
     test_read(p_in, close_session_rpl, __LINE__);
 
     assert_int_equal(nc_ps_session_count(np2srv.nc_ps), 1);
-    assert_int_equal(num_sessions, 1);
+    assert_int_equal(ATOMIC_LOAD(num_sessions), 1);
 }
 
 int


### PR DESCRIPTION
A memory leak reg. nc-poll-sessions has been detected during shutting down netopeer2-server. This PR provides test case and solution.

Regards,
Frank