### PR TITLE
tests: Enable parallel test execution

### DIFF
--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ foreach(test_name IN LISTS tests)
     endif()
     set_target_properties(${test_name} PROPERTIES LINK_FLAGS "${${test_name}_wrap_link_flags}")
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+    target_compile_definitions(${test_name} PRIVATE TEST_NAME="${test_name}")
 endforeach(test_name)
 
 configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_BINARY_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)

--- a/server/tests/test_close_session.c
+++ b/server/tests/test_close_session.c
@@ -28,7 +28,7 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #include "../main.c"
 

--- a/server/tests/test_copy_config.c
+++ b/server/tests/test_copy_config.c
@@ -38,10 +38,10 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #ifdef NP2SRV_ENABLED_URL_CAPABILITY
-#define URL_TESTFILE "/tmp/nc2_copy_config.xml"
+#define URL_TESTFILE "/tmp/nc2-" TEST_NAME ".xml"
 #endif
 
 #include "../main.c"

--- a/server/tests/test_delete_config.c
+++ b/server/tests/test_delete_config.c
@@ -38,10 +38,10 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #ifdef NP2SRV_ENABLED_URL_CAPABILITY
-#define URL_TESTFILE "/tmp/nc2_delete_config.xml"
+#define URL_TESTFILE "/tmp/nc2-" TEST_NAME ".xml"
 #endif
 
 #include "../main.c"

--- a/server/tests/test_edit_get_config.c
+++ b/server/tests/test_edit_get_config.c
@@ -34,10 +34,10 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #ifdef NP2SRV_ENABLED_URL_CAPABILITY
-#define URL_TESTFILE "/tmp/nc2_edit_config.xml"
+#define URL_TESTFILE "/tmp/nc2-" TEST_NAME ".xml"
 #endif
 
 #include "../main.c"

--- a/server/tests/test_generic.c
+++ b/server/tests/test_generic.c
@@ -29,7 +29,7 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #include "../main.c"
 

--- a/server/tests/test_get.c
+++ b/server/tests/test_get.c
@@ -29,7 +29,7 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #include "../main.c"
 

--- a/server/tests/test_kill.c
+++ b/server/tests/test_kill.c
@@ -28,7 +28,7 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #include "../main.c"
 

--- a/server/tests/test_notif.c
+++ b/server/tests/test_notif.c
@@ -32,7 +32,7 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #include "../main.c"
 

--- a/server/tests/test_un_lock.c
+++ b/server/tests/test_un_lock.c
@@ -29,7 +29,7 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #include "../main.c"
 

--- a/server/tests/test_validate_config.c
+++ b/server/tests/test_validate_config.c
@@ -34,10 +34,10 @@
 
 #define main server_main
 #undef NP2SRV_PIDFILE
-#define NP2SRV_PIDFILE "/tmp/test_np2srv.pid"
+#define NP2SRV_PIDFILE "/tmp/test_np2srv-" TEST_NAME ".pid"
 
 #ifdef NP2SRV_ENABLED_URL_CAPABILITY
-#define URL_TESTFILE "/tmp/nc2_validate_config.xml"
+#define URL_TESTFILE "/tmp/nc2-" TEST_NAME ".xml"
 #endif
 
 #include "../main.c"


### PR DESCRIPTION
All tests were trying to use the same PID file, and therefore they would fail to start properly and eventually hit a timeout, outputting an error:
```
 [ RUN      ] test_startstop
 [ERR]: Another instance of the Netopeer2 server is running.
```
I cannot use `__FILE__` directly because that one might contain full path. There's `__builtin_strchr`, but doing this via CMake is probably a bit easier.

Also adjust the temporary file name for XML operations to be consistent.