### PR TITLE
[🐛 FIX] segmentation fault on CLI when using pipe

### DIFF
--- a/cli/linenoise/linenoise.c
+++ b/cli/linenoise/linenoise.c
@@ -325,7 +325,7 @@ static void freeCompletions(linenoiseCompletions *lc) {
         free(lc->cvec);
 }
 
-/* This is an helper function for linenoiseEdit() and is called when the
+/* This is a helper function for linenoiseEdit() and is called when the
  * user types the <tab> key in order to complete the string currently in the
  * input.
  *
@@ -549,7 +549,7 @@ void linenoiseAddCompletion(linenoiseCompletions *lc, const char *str) {
 
 /* =========================== Line editing ================================= */
 
-/* We define a very simple "append buffer" structure, that is an heap
+/* We define a very simple "append buffer" structure, that is a heap
  * allocated string where we can append to. This is useful in order to
  * write all the escape sequences in a buffer and flush them to the standard
  * output in a single call, to avoid flickering effects. */
@@ -1153,14 +1153,10 @@ int linenoiseHistoryAdd(const char *line, void *data) {
 
     /* Don't add duplicated lines. */
     if (ls.history_len && !strcmp(ls.history[ls.history_len-1].line, line)) {
-        if (ls.hist_data_free) {
-            ls.hist_data_free(ls.history[ls.history_len-1].data);
-        }
-        ls.history[ls.history_len-1].data = data;
         return 0;
     }
 
-    /* Add an heap allocated copy of the line in the history.
+    /* Add a heap allocated copy of the line in the history.
      * If we reached the max length, remove the older line. */
     linecopy = strdup(line);
     if (!linecopy) return 0;


### PR DESCRIPTION
Netopeer2 CLI 2.0.51
Compile time: Mar 22 2019, 15:55:56

Using pipe as input to `netopeer2-cli` is an easy way to automate some netconf commands.
But it crashes on duplicate commands. Sometimes. It might depend on the contents of history that is dumped to the file at the time that you start `netopeer2-cli`. There have been times where this didn't replicate for me.

![netopeer2-cli segmentation fault](https://andrei-pavel.github.io/showcase/netopeer2-cli-segmentation-fault.svg)

If it were a double free, checking for null would have fixed it.
It rather seems to be a stack corruption.
Looked at the address of `ls.history[ls.history_len-1].data` one time and it was `0x21`.