### PR TITLE
Switch X509_get_notAfter to get0 variant

### DIFF
--- a/cli/commands.c
+++ b/cli/commands.c
@@ -1659,7 +1659,11 @@ parse_cert(const char *name, const char *path)
     BIO_printf(bio_out, "\n");
 
     BIO_printf(bio_out, "Valid until: ");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
     ASN1_TIME_print(bio_out, X509_get_notAfter(cert));
+#else
+    ASN1_TIME_print(bio_out, X509_get0_notAfter(cert));
+#endif
     BIO_printf(bio_out, "\n");
 
     has_san = 0;


### PR DESCRIPTION
The former is deprecated.