### PR TITLE
keystored: force public key in pem format

### DIFF
--- a/keystored/scripts/ssh-key-import.sh
+++ b/keystored/scripts/ssh-key-import.sh
@@ -28,8 +28,14 @@ else
     else
         echo "- SSH hostkey not found, generating a new one..."
         $SSH_KEYGEN -m pem -t rsa -q -N "" -f ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem
+        # public key format cannot be specified, it is always in the openssh format
+        # force convert it to PEM as well
+        $CHMOD go-rw ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem.pub
+        $SSH_KEYGEN -e -m pem -f ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem.pub > ${KEYSTORED_KEYS_DIR}/pub.pem
+        mv -f ${KEYSTORED_KEYS_DIR}/pub.pem ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem.pub
     fi
     $CHMOD go-rw ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem
+    $CHMOD go+r ${KEYSTORED_KEYS_DIR}/ssh_host_rsa_key.pem.pub
     echo "- Importing ietf-keystore stock key configuration..."
     $SYSREPOCFG -d startup -i ${STOCK_KEY_CONFIG} ietf-keystore
 fi


### PR DESCRIPTION
Fix the following error:

```
[ERR] File "/etc/keystored/keys/ssh_host_rsa_key.pem.pub" is not a public key in PEM format.
```

ssh-keygen ignores the `-m pem` argument for the public key file. It always generates it in the openssh format.

Convert it to PEM afterwards.

`ssh-keygen` requires that the converted file has `0600` permissions (it assumes it is a private key). Restrict permissions before converting and restore them afterwards.