### PR TITLE
server: disable cwd yang search dir

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -974,7 +974,7 @@ np2srv_init_schemas(void)
     /* build libyang context */
     /* the lock is not supposed to be locked here. In case of first calling, it needn't be used because we are still
      * single-threaded, in other cases the caller (np2srv_module_install_clb()) is supposed to lock it */
-    np2srv.ly_ctx = ly_ctx_new(NULL, 0);
+    np2srv.ly_ctx = ly_ctx_new(NULL, LY_CTX_DISABLE_SEARCHDIR_CWD);
     if (!np2srv.ly_ctx) {
         goto error;
     }


### PR DESCRIPTION
When creating the libyang context, disable searching for yang modules in the current working directory. Depending on where `netopeer2-server` is started, we can get surprising warnings/errors:

For example, when starting the server from `/`:

```
Reading module "ietf-yang-library".
Searching for "ietf-yang-types" in /.
Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
...
Module "ietf-yang-library@2019-01-04" successfully parsed as implemented.
```

In that case, the "non-exsistant" items are symlinks:

```
~# ls -lhF /initrd* /vmlinuz*
lrwxrwxrwx 1 root root 32 Aug 14 16:19 /initrd.img -> boot/initrd.img-5.0.0-20-generic
lrwxrwxrwx 1 root root 32 Aug 14 16:35 /initrd.img.old -> boot/initrd.img-5.0.0-20-generic
lrwxrwxrwx 1 root root 29 Aug 14 16:19 /vmlinuz -> boot/vmlinuz-5.0.0-20-generic
lrwxrwxrwx 1 root root 29 Aug 14 16:35 /vmlinuz.old -> boot/vmlinuz-5.0.0-20-generic
```

I am not sure why we get this `No such file or directory` error but I cannot find a good reason to search for yang modules in the current directory anyway.