### PR TITLE
server BUGFIX fix partial processing of tcp params changes

### DIFF
--- a/server/netconf_server.c
+++ b/server/netconf_server.c
@@ -140,6 +140,8 @@ np2srv_tcp_keepalives(const char *client_name, const char *endpt_name, sr_sessio
         return rc;
     }
 
+    rc = 0;
+
     /* set new keepalive parameters */
     if (!client_name) {
         if (nc_server_is_endpt(endpt_name)) {
@@ -151,6 +153,7 @@ np2srv_tcp_keepalives(const char *client_name, const char *endpt_name, sr_sessio
         }
     }
     if (rc) {
+        ERR("Keepalives configuration failed (%d).", rc);
         return SR_ERR_INTERNAL;
     }
 


### PR DESCRIPTION
When deleting an enpoint, neither `nc_server_endpt_set_keepalives` nor `nc_server_ch_client_endpt_set_keepalives` are called. `rc` remains with its current value which is necessarily `SR_ERR_NOT_FOUND` (meaning "end of changes").

This causes `np2srv_tcp_keepalives` to return `SR_ERR_INTERNAL` which causes `np2srv_endpt_tcp_params_cb` to stop processing the changes and return an error. No error message is printed.

Reset the value of `rc` to fix the issue.

If one of `nc_server_ch_client_endpt_set_keepalives` or `nc_server_endpt_set_keepalives` actually failed, display an explicit error message.