### PR TITLE
Fix list and leaf-list moves

### DIFF
--- a/server/op_editconfig.c
+++ b/server/op_editconfig.c
@@ -28,6 +28,9 @@
 #include "common.h"
 #include "operations.h"
 
+/* there is no enum for "no move", and the name SR_MOVE_LAST suggests that it might be the last item of an enum */
+#define SR_MOVE_INVALID_SENTINEL 666
+
 static enum NP2_EDIT_OP
 edit_get_op(struct lyd_node *node, enum NP2_EDIT_OP parentop, enum NP2_EDIT_DEFOP defop)
 {
@@ -168,7 +171,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
     struct nc_server_reply *ereply = NULL;
     struct np2_sessions *sessions = NULL;
     sr_datastore_t ds = 0;
-    sr_move_position_t pos = SR_MOVE_LAST;
+    sr_move_position_t pos = SR_MOVE_INVALID_SENTINEL;
     sr_val_t value;
     struct ly_set *nodeset;
     /* default value for default-operation is "merge" */
@@ -436,7 +439,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
             }
 
             DBG("EDIT_CONFIG: leaflist %s, operation %s", path, op2str(op[op_index]));
-            if (pos != SR_MOVE_LAST) {
+            if (pos != SR_MOVE_INVALID_SENTINEL) {
                 DBG("EDIT_CONFIG: moving leaflist %s, position %d (%s)", path, pos, rel ? rel : "absolute");
             }
 
@@ -540,10 +543,10 @@ resultcheck:
         }
 
         /* move user-ordered list/leaflist */
-        if (pos != SR_MOVE_LAST) {
+        if (pos != SR_MOVE_INVALID_SENTINEL) {
             ret = np2srv_sr_move_item(sessions->srs, path, pos, rel, &ereply);
             free(rel);
-            pos = SR_MOVE_LAST;
+            pos = SR_MOVE_INVALID_SENTINEL;
             goto resultcheck;
         }
 

--- a/server/op_editconfig.c
+++ b/server/op_editconfig.c
@@ -384,7 +384,6 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
 
         /* specific work for different node types */
         ret = -1;
-        rel = NULL;
         lastkey = 0;
         np_cont = 0;
         switch (iter->schema->nodetype) {
@@ -433,6 +432,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
             DBG("EDIT_CONFIG: leaf %s, operation %s", path, op2str(op[op_index]));
             break;
         case LYS_LEAFLIST:
+            rel = NULL;
             /* get info about inserting to a specific place */
             if (edit_get_move(iter, path, &pos, &rel)) {
                 goto internalerror;
@@ -458,6 +458,7 @@ op_editconfig(struct lyd_node *rpc, struct nc_session *ncs)
 
             break;
         case LYS_LIST:
+            rel = NULL;
             /* get info about inserting to a specific place */
             if (edit_get_move(iter, path, &pos, &rel)) {
                 goto internalerror;


### PR DESCRIPTION
Two fixes for issues in moving of `list` and `leaf-list` YANG types (#636 by @syyyr). I don't know whether the non-legacy branch also has these bugs (I have not found any tests for moves neither in `legacy`, nor in `master`).

## Allow moving list/leaf-list items to the last position

The code wanted to deliberately ignore any `SR_MOVE_LAST` values. I think that this happened because of that C convention for adding a `FOO_LAST` items to enums to signify their largest allowed value.
    
I did not want to modify sysrepo for this as well, so I just added a random garbage sentinel for this.
    
## Do not reset relative list XPath too early

When processing YANG list moves, the code would correctly parse the relative XPath in the `edit_get_move()`, but before it could be consumed via `np2srv_sr_move_item`, it got reset when the main iteration loop processes the next change item. As a result, a relative move operation was always attempted with a `nullptr` for the relative item XPath.
    
Fix this by only resetting the `rel` when encountering a new `leaf-list` or a new `list`. I have no clue if this is actually correct (what about nested lists, for example?). However, my C skills are too limited to correctly follow constructs with `goto`s into the middle of if statements, so this is my best attempt -- sorry.