### PR TITLE
script.sh: take DESTDIR into account

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ fi
 
 # avoid problems with sudo path
 SYSREPOCTL=`su -c "which sysrepoctl" $USER`
-MODDIR=${NP2_MODULE_DIR}
+MODDIR=${DESTDIR}${NP2_MODULE_DIR}
 PERMS=${NP2_MODULE_PERMS}
 OWNER=${NP2_MODULE_OWNER}
 GROUP=${NP2_MODULE_GROUP}


### PR DESCRIPTION
When installing yang modules add DESTDIR prefix to the NP2_MODULE_DIR.

Fixes #648

Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>