### PR TITLE
fixed several <error-tags> (issue#654)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -344,9 +344,28 @@ err_access_denied:
         /* fallthrough */
     default:
         if (strstr(message, "authorization failed")) {
+            // access-denied
             goto err_access_denied;
-        } else if (strstr(message, "is already locked")) {
+        } else if (strstr(message, "is already locked") ||
+                   strstr(message, "Module \"yang\" is locked by session")) {
+            // lock-denied
             goto err_lock_denied;
+        } else if (strstr(message, "is locked by session")) {
+            // in-use
+            e = nc_err(NC_ERR_IN_USE, NC_ERR_TYPE_PROT);
+            nc_err_set_msg(e, message, "en");
+            if (xpath) {
+                nc_err_set_path(e, xpath);
+            }
+            break;
+        } else if (strstr(message, "already exists")) {
+            // data-exists
+            e = nc_err(NC_ERR_DATA_EXISTS);
+            nc_err_set_msg(e, message, "en");
+            if (xpath) {
+                nc_err_set_path(e, xpath);
+            }
+            break;
         } else if (strstr(message, "Source and target")) {
             e = nc_err(NC_ERR_INVALID_VALUE, NC_ERR_TYPE_PROT);
             nc_err_set_msg(e, message, "en");


### PR DESCRIPTION
Fixes #654 
This is an attempt to fix following  `<error-tag>` values which were reported as `operation-failed` but shall be more specific:
- `<lock-denied>`
- `<in-use>`
- `<data-exist>`

The proposed solution here is based on the initial fix 2bd857b - to parse the message parameter in np2srv_err_sr().

There might be many more error-tags missing, though, which needs to be added case-by-case. 

IMO, more SR_ERR_XXX values for each error-tag use case would be easier to handle, though. 