### PR TITLE
Ignore key reading failure if not running as root

### DIFF
--- a/src/netconf_server_ssh.c
+++ b/src/netconf_server_ssh.c
@@ -431,11 +431,16 @@ np2srv_endpt_ssh_auth_users_oper_cb(sr_session_ctx_t *UNUSED(session), const cha
         }
         f = fopen(path, "r");
         if (!f) {
-            if (errno != ENOENT) {
+            if (errno != ENOENT && errno != EACCES) {
                 ERR("Opening \"%s\" authorized key file failed (%s).", path, strerror(errno));
                 free(path);
                 goto cleanup;
             }
+
+            if (errno == EACCES) {
+                VRB("Skipping \"%s\" authorized key file (%s).", path, strerror(errno));
+            }
+
             free(path);
             continue;
         }


### PR DESCRIPTION
Running Netopeer2 as a normal user is a good use-case for testing.

In my test, I try to get all data available (with a `/*` filter). through sysrepo, but this callback errored out, when root access wasn't available.

cc @jktjkt 