### PR TITLE
build FEATURE add env var sysrepo tools override

### DIFF
--- a/scripts/merge_config.sh
+++ b/scripts/merge_config.sh
@@ -2,8 +2,11 @@
 
 set -e
 
+# optional env variable override
+if [ -n "$SYSREPOCFG_EXECUTABLE" ]; then
+    SYSREPOCFG="$SYSREPOCFG_EXECUTABLE"
 # avoid problems with sudo PATH
-if [ `id -u` -eq 0 ]; then
+elif [ `id -u` -eq 0 ]; then
     SYSREPOCFG=`su -c 'which sysrepocfg' -l $USER`
 else
     SYSREPOCFG=`which sysrepocfg`

--- a/scripts/merge_hostkey.sh
+++ b/scripts/merge_hostkey.sh
@@ -2,12 +2,20 @@
 
 set -e
 
+# optional env variable override
+if [ -n "$SYSREPOCFG_EXECUTABLE" ]; then
+    SYSREPOCFG="$SYSREPOCFG_EXECUTABLE"
 # avoid problems with sudo PATH
-if [ `id -u` -eq 0 ]; then
+elif [ `id -u` -eq 0 ]; then
     SYSREPOCFG=`su -c 'which sysrepocfg' -l $USER`
-    OPENSSL=`su -c 'which openssl' -l $USER`
 else
     SYSREPOCFG=`which sysrepocfg`
+fi
+
+# avoid problems with sudo PATH
+if [ `id -u` -eq 0 ]; then
+    OPENSSL=`su -c 'which openssl' -l $USER`
+else
     OPENSSL=`which openssl`
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,8 +7,11 @@ if [ -z "$NP2_MODULE_DIR" -o -z "$NP2_MODULE_PERMS" ]; then
     exit 1
 fi
 
+# optional env variable override
+if [ -n "$SYSREPOCTL_EXECUTABLE" ]; then
+    SYSREPOCTL="$SYSREPOCTL_EXECUTABLE"
 # avoid problems with sudo PATH
-if [ `id -u` -eq 0 ]; then
+elif [ `id -u` -eq 0 ]; then
     SYSREPOCTL=`su -c 'which sysrepoctl' -l $USER`
 else
     SYSREPOCTL=`which sysrepoctl`


### PR DESCRIPTION
In my dev environment, there is no sysrepoctl or sysrepocfg in `PATH`. I usually have two versions of the netconf stack installed (at the same time): one with sanitizers and one without, so the scripts wouldn't know which binary to use (and they are usually incompatible). I added an env var override for sysrepoctl and sysrepocfg.

Also, feel free to (completely) change the commit message if you want, I'm not sure if I got that right.

Thanks