### PR TITLE
Fix odr-violation

### DIFF
--- a/src/netconf_acm.c
+++ b/src/netconf_acm.c
@@ -28,7 +28,7 @@
 #include "log.h"
 #include "netconf_acm.h"
 
-struct ncac nacm;
+static struct ncac nacm;
 
 /* /ietf-netconf-acm:nacm */
 int


### PR DESCRIPTION
Hi, in our CI, this error came up
```
=================================================================
==2083==ERROR: AddressSanitizer: odr-violation (0x000000e7bc00):
  [1] size=96 'nacm' /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libyang/src/extensions/nacm.c:157:26
  [2] size=88 'nacm' /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/Netopeer2/src/netconf_acm.c:31:13
These globals were registered at these points:
  [1]:
    #0 0x436418 in __asan_register_globals.part.0 (/home/ci/target/bin/netopeer2-server+0x436418)
    #1 0x7f9a53a49ebb in asan.module_ctor (/home/ci/target/lib64/libyang1/extensions/nacm.so+0x2ebb)

  [2]:
    #0 0x436418 in __asan_register_globals.part.0 (/home/ci/target/bin/netopeer2-server+0x436418)
    #1 0x5357ae in asan.module_ctor (/home/ci/target/bin/netopeer2-server+0x5357ae)

==2083==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'nacm' at /home/ci/src/cesnet-gerrit-public/CzechLight/dependencies/libyang/src/extensions/nacm.c:157:26
==2083==ABORTING
```
This patch fixes this by making the nacm variable static.