### PR TITLE
scripts: Limit activity to the startup datastore

### DIFF
--- a/scripts/merge_config.sh
+++ b/scripts/merge_config.sh
@@ -14,7 +14,7 @@ fi
 KS_KEY_NAME=genkey
 
 # check that there is no listen/Call Home configuration yet
-SERVER_CONFIG=`$SYSREPOCFG -X -x "/ietf-netconf-server:netconf-server/listen/endpoint[1]/name | /ietf-netconf-server:netconf-server/call-home/netconf-client[1]/name"`
+SERVER_CONFIG=`$SYSREPOCFG -d startup -X -x "/ietf-netconf-server:netconf-server/listen/endpoint[1]/name | /ietf-netconf-server:netconf-server/call-home/netconf-client[1]/name"`
 if [ -z "$SERVER_CONFIG" ]; then
 
 # import default config
@@ -55,9 +55,8 @@ CONFIG="<netconf-server xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-server\
 </netconf-server>"
 TMPFILE=`mktemp -u`
 printf -- "$CONFIG" > $TMPFILE
-# apply it to startup and running
+# apply it to startup
 $SYSREPOCFG --edit=$TMPFILE -d startup -f xml -m ietf-netconf-server -v2
-$SYSREPOCFG -C startup -m ietf-netconf-server -v2
 # remove the tmp file
 rm $TMPFILE
 

--- a/scripts/merge_hostkey.sh
+++ b/scripts/merge_hostkey.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # check that there is no SSH key with this name yet
-KEYSTORE_KEY=`$SYSREPOCFG -X -x "/ietf-keystore:keystore/asymmetric-keys/asymmetric-key[name='genkey']/name"`
+KEYSTORE_KEY=`$SYSREPOCFG -d startup -X -x "/ietf-keystore:keystore/asymmetric-keys/asymmetric-key[name='genkey']/name"`
 if [ -z "$KEYSTORE_KEY" ]; then
 
 # generate a new key
@@ -51,9 +51,8 @@ CONFIG="<keystore xmlns=\"urn:ietf:params:xml:ns:yang:ietf-keystore\">
 </keystore>"
 TMPFILE=`mktemp -u`
 printf -- "$CONFIG" > $TMPFILE
-# apply it to startup and running
+# apply it to startup
 $SYSREPOCFG --edit=$TMPFILE -d startup -f xml -m ietf-keystore -v2
-$SYSREPOCFG -C startup -m ietf-keystore -v2
 # remove the tmp file
 rm $TMPFILE
 


### PR DESCRIPTION
This script used to check the `running` datastore for presence of configuration statements. That doesn't work when Netopeer2 is not running. Make sure that we only touch the `startup` DS, and delegate any updates of the `running` DS to the usual mechanism (i.e., upon the first subscription).