### PR TITLE
Compile-time options for specifying custom paths of authorized_keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,12 @@ if(NOT PIDFILE_PREFIX)
     set(PIDFILE_PREFIX "/var/run")
 endif()
 
+set(NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN "%s/.ssh/authorized_keys" CACHE STRING "printf-like pattern for determining path to users' SSH authorized_keys file. Must contain exactly one '%s'.")
+set(NP2SRV_SSH_AUTHORIZED_KEYS_ARG_IS_USERNAME 0 CACHE STRING "If true, replace '%s' by username. If not set, replace '%s' by home directory. By default, unset.")
+if(NOT NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN MATCHES "^[^%]*%s[^%]*$")
+    message(FATAL_ERROR "Wrong format string given for NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN: exactly one '%s' expected.")
+endif()
+
 # check that lnc2 supports np2srv thread count
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -98,4 +98,9 @@
  */
 #define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
 
+/** @brief printf-like pattern for path to the authorized_keys file */
+#define NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN "@NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN@"
+/** @brief Replace %s in NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN by username (1), or by the home dir (0) */
+#cmakedefine01 NP2SRV_SSH_AUTHORIZED_KEYS_ARG_IS_USERNAME
+
 #endif /* NP2SRV_CONFIG_H_ */

--- a/src/netconf_server_ssh.c
+++ b/src/netconf_server_ssh.c
@@ -29,6 +29,7 @@
 #include <libyang/libyang.h>
 #include <sysrepo.h>
 
+#include "config.h"
 #include "common.h"
 #include "log.h"
 #include "netconf_server.h"
@@ -97,7 +98,7 @@ np2srv_pubkey_auth_cb(const struct nc_session *session, ssh_key key, void *UNUSE
     }
 
     /* check any authorized keys */
-    r = asprintf(&line, "%s/.ssh/authorized_keys", pwd->pw_dir);
+    r = asprintf(&line, NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN, NP2SRV_SSH_AUTHORIZED_KEYS_ARG_IS_USERNAME ? pwd->pw_name : pwd->pw_dir);
     if (r == -1) {
         EMEM;
         line = NULL;
@@ -425,7 +426,7 @@ np2srv_endpt_ssh_auth_users_oper_cb(sr_session_ctx_t *UNUSED(session), const cha
         lyd_new_leaf(user, NULL, "name", pwd->pw_name);
 
         /* check any authorized keys */
-        if (asprintf(&path, "%s/.ssh/authorized_keys", pwd->pw_dir) == -1) {
+        if (asprintf(&path, NP2SRV_SSH_AUTHORIZED_KEYS_PATTERN, NP2SRV_SSH_AUTHORIZED_KEYS_ARG_IS_USERNAME ? pwd->pw_name : pwd->pw_dir) == -1) {
             EMEM;
             goto cleanup;
         }


### PR DESCRIPTION
Our appliance uses a read-only rootfs, and we're therefore managing the users' SSH pubkeys within a config-only partition. That's outside of their individual home directories.

Cc: #811 