### PR TITLE
acm: fix segmentation fault when session is disconnected

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -76,6 +76,7 @@ np2srv_ntf_new_cb(sr_session_ctx_t *UNUSED(session), const sr_ev_notif_type_t no
     struct nc_server_notif *nc_ntf = NULL;
     struct nc_session *ncs = (struct nc_session *)private_data;
     struct lyd_node *ly_ntf = NULL;
+    const char *username;
     NC_MSG_TYPE msg_type;
     char buf[26], *datetime;
 
@@ -94,7 +95,12 @@ np2srv_ntf_new_cb(sr_session_ctx_t *UNUSED(session), const sr_ev_notif_type_t no
     }
 
     /* check NACM */
-    if (ncac_check_operation(notif, nc_session_get_username(ncs))) {
+    username = nc_session_get_username(ncs);
+    if (!username) {
+        EINT;
+        goto cleanup;
+    }
+    if (ncac_check_operation(notif, username)) {
         goto cleanup;
     }
 

--- a/src/netconf_acm.c
+++ b/src/netconf_acm.c
@@ -786,6 +786,10 @@ ncac_getpwnam(const char *user, uid_t *uid, gid_t *gid)
     ssize_t buflen;
     int ret;
 
+    if (user == NULL) {
+        ERR("Cannot get user NULL pwd entry");
+        return -1;
+    }
     buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (buflen == -1) {
         buflen = 2048;

--- a/src/netconf_nmda.c
+++ b/src/netconf_nmda.c
@@ -98,6 +98,7 @@ np2srv_rpc_getdata_cb(sr_session_ctx_t *session, const char *UNUSED(op_path), co
     int i, rc = SR_ERR_OK;
     uint32_t max_depth = 0;
     struct ly_set *nodeset;
+    const char *username;
     sr_datastore_t ds;
     NC_WD_MODE nc_wd;
     sr_get_oper_options_t get_opts = 0;
@@ -215,8 +216,15 @@ np2srv_rpc_getdata_cb(sr_session_ctx_t *session, const char *UNUSED(op_path), co
     }
     ly_set_free(nodeset);
 
+    username = np_get_nc_sess_user(session);
+    if (!username) {
+        /* NC session was disconnected while waiting for sysrepo data */
+        EINT;
+        rc = SR_ERR_INTERNAL;
+        goto cleanup;
+    }
     /* perform correct NACM filtering */
-    ncac_check_data_read_filter(&data, np_get_nc_sess_user(session));
+    ncac_check_data_read_filter(&data, username);
 
     /* add output */
     node = lyd_new_output_anydata(output, NULL, "data", data, LYD_ANYDATA_DATATREE);


### PR DESCRIPTION
If NETCONF session was disconnected while waiting for sr_get_data, before filtering the returned data np_get_nc_sess_user() returns NULL, then user will be NULL as well.

This translates in ncac_getpwnam calling getpwdnam_r() with user=NULL. getpwdnam_r() may call _nss_compat_getpwnam_r() which accesses user[0] without checking if user is NULL first.

This causes a segmentation fault:

```
 Stack trace:
 #0      _nss_compat_getpwnam_r (libnss_compat.so.2)
 #1      getpwnam_r (libc.so.6)
 #2      n/a (netopeer2-server)
 #3      n/a (netopeer2-server)
 #4      ncac_check_data_read_filter (netopeer2-server)
 #5      np2srv_rpc_get_cb (netopeer2-server)
 #6      n/a (libsysrepo.so.5)
 #7      n/a (libsysrepo.so.5)
 #8      sr_process_events (libsysrepo.so.5)
 #9      n/a (libsysrepo.so.5)
 #10     start_thread (libpthread.so.0)
 #11     __clone (libc.so.6)
```

Avoid calling ncac_check_data_read_filter if np_get_nc_sess_user returns NULL.

Also, for good measure, check for the user argument value in ncac_getpwnam and avoid calling getpwdnam_r if it is NULL.

Fixes: #818
Link: https://sourceware.org/git/?p=glibc.git;a=blob;f=nss/nss_compat/compat-pwd.c;h=f536754559ad;hb=HEAD#l819