### PR TITLE
Allow key-names in rule target path.

### DIFF
--- a/src/netconf_acm.c
+++ b/src/netconf_acm.c
@@ -1027,6 +1027,21 @@ ncac_allowed_path(const char *rule_target, const char *node_path)
             }
 
             ++node_ptr;
+        } else if ((rule_ptr[0] == ']') && (node_ptr[0] == '=')) {
+            /* There is a key/value contained in the node_path but a only the key-name in the rule target. */
+            while (node_ptr[0] != ']') {
+                if (node_ptr[0] == '\'') {
+                    do {
+                        ++node_ptr;
+                    } while (node_ptr[0] != '\'');
+                }
+
+                ++node_ptr;
+            }
+
+            ++node_ptr;
+            /* Proceed to the character after the closing bracket. */
+            ++rule_ptr;
         } else {
             /* not a match */
             return 0;


### PR DESCRIPTION
Precondition:
- The fix from PR #865 has been applied.
- A RADIUS server with the corresponding shared-secret has been configured.
- The following NACM rules have been configured:
```xml
    <nacm:nacm xmlns:nacm="urn:ietf:params:xml:ns:yang:ietf-netconf-acm" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
        <nacm:rule-list>
            <nacm:name>EXAMPLE</nacm:name>
            <nacm:group>EXAMPLE</nacm:group>
            <nacm:rule>
                <nacm:name>denyRadiusSecret</nacm:name>
                <nacm:action>deny</nacm:action>
                <nacm:path xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">/sys:system/sys:radius/sys:server[sys:name]/sys:udp/sys:shared-secret</nacm:path>
            </nacm:rule>
            <nacm:rule>
                <nacm:name>denyRadiusSecret</nacm:name>
                <nacm:access-operations>read</nacm:access-operations>
                <nacm:action>permit</nacm:action>
                <nacm:path xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">/sys:system/sys:radius/sys:server/*</nacm:path>
            </nacm:rule>
            <nacm:rule>
                <nacm:name>allowRead</nacm:name>
                <nacm:access-operations>*</nacm:access-operations>
                <nacm:action>permit</nacm:action>
                <nacm:module-name>*</nacm:module-name>
            </nacm:rule>
        </nacm:rule-list>
    </nacm:nacm>
```
Expectation:
The result of a get-config shall not contain the shared-secret.

Observation:
The shared-secret is contained in the RPC reply.

Cause:
This behavior is because the partial match of the target path in the rule "denyRadiusSecret" is not detected.
Here the additional key-name "[sys:name]" in the path is not considered by the function "ncac_allowed_path()"
although it results in a valid XPath.

Correction:
A adapted loop searching for the closing bracket in the node path has been added to "ncac_allowed_path()"
triggered by ']' in the rule target path and '=' in the node's path.
