### PR TITLE
misc Ci fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,10 @@ set(CMAKE_C_FLAGS_DEBUG     "-g -O0")
 #
 # options
 #
+option(ENABLE_TESTS "Build tests" ON)
 if(("${BUILD_TYPE_UPPER}" STREQUAL "DEBUG") OR ("${BUILD_TYPE_UPPER}" STREQUAL "RELWITHDEBINFO"))
-    option(ENABLE_TESTS "Build tests" ON)
     option(ENABLE_VALGRIND_TESTS "Build tests with valgrind" ON)
 else()
-    option(ENABLE_TESTS "Build tests" OFF)
     option(ENABLE_VALGRIND_TESTS "Build tests with valgrind" OFF)
 endif()
 option(ENABLE_COVERAGE "Build code coverage report from tests" OFF)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Netopeer2 – NETCONF Server
 
 [![BSD license](https://img.shields.io/badge/License-BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Build Status](https://secure.travis-ci.org/CESNET/Netopeer2.png?branch=master)](http://travis-ci.org/CESNET/Netopeer2)
+[![Build Status](https://github.com/CESNET/netopeer2/workflows/netopeer2%20CI/badge.svg)](https://github.com/CESNET/netopeer2/actions?query=workflow%3A%22netopeer2+CI%22)
 [![Coverity](https://scan.coverity.com/projects/8416/badge.svg)](https://scan.coverity.com/projects/8416)
 [![Codecov](https://codecov.io/gh/CESNET/netopeer2/branch/master/graph/badge.svg?token=ue4DTHDcuq)](https://codecov.io/gh/CESNET/netopeer2)
 [![Ohloh Project Status](https://www.openhub.net/p/Netopeer2/widgets/project_thin_badge.gif)](https://www.openhub.net/p/Netopeer2)


### PR DESCRIPTION
## build: do not disable testing on release builds
    
There's no need to skip testing for release builds. On the contrary, given that the release build is something that the end users will run, it makes sense to test the release builds as well.

## docs: point to GitHub Actions for CI results