### PR TITLE
tests: check asprintf()'s results

### DIFF
--- a/tests/test_parallel_sessions.c
+++ b/tests/test_parallel_sessions.c
@@ -78,7 +78,7 @@ recv_reply_error_print(struct np_test *st, const struct lyd_node *op, const stru
 
     /* print netopeer2 log */
     printf("np2 log:\n");
-    asprintf(&path, "%s/%s/%s", NP_SR_REPOS_DIR, st->test_name, NP_LOG_FILE);
+    assert_int_not_equal(-1, asprintf(&path, "%s/%s/%s", NP_SR_REPOS_DIR, st->test_name, NP_LOG_FILE));
     f = fopen(path, "r");
     free(path);
     if (!f) {


### PR DESCRIPTION
```
Netopeer2/tests/test_parallel_sessions.c:81:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    asprintf(&path, "%s/%s/%s", NP_SR_REPOS_DIR, st->test_name, NP_LOG_FILE);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/f1r94qx7a8m8iz7fxvlq655gbawql7xf-glibc-2.33-50-dev/include/bits/stdio2.h:207:3: note: expanded from macro 'asprintf'
  __asprintf_chk (ptr, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
  ^~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

Fixes: 8c6e102 test FEATURE print np2 log on unexpected reply