### PR TITLE
Fix build when not using CMake's make generator

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,10 +52,14 @@ foreach(test_name IN LISTS tests)
     set_property(TARGET ${test_name} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endforeach(test_name)
 
+set(TEST_KILL_SERVER_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/scripts/kill_np_server.sh)
+set(TEST_CLEAR_STATE_COMMAND rm -rf /dev/shm/_tests_np_*)
 if(${CMAKE_VERSION} VERSION_GREATER "3.7")
-    # tests cleanup fixture, keep repos with server log files
-    add_test(NAME tests_done COMMAND make test_clean_keep_repos)
-    set_tests_properties(tests_done PROPERTIES FIXTURES_CLEANUP tests_cleanup)
+    # tests cleanup fixtures, keep repos with server log files
+    add_test(NAME tests_kill_server COMMAND ${TEST_KILL_SERVER_COMMAND})
+    add_test(NAME tests_clear_state COMMAND ${TEST_CLEAR_STATE_COMMAND})
+    set_tests_properties(tests_kill_server PROPERTIES FIXTURES_CLEANUP tests_cleanup)
+    set_tests_properties(tests_clear_state PROPERTIES FIXTURES_CLEANUP tests_cleanup DEPENDS tests_kill_server)
 endif()
 
 # add tests with their attributes
@@ -81,11 +85,8 @@ if(ENABLE_VALGRIND_TESTS)
 endif()
 
 # phony target for clearing all sysrepo test data
-add_custom_target(test_clean_keep_repos
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/scripts/kill_np_server.sh
-    COMMAND rm -rf /dev/shm/_tests_np_*
-)
 add_custom_target(test_clean
-    DEPENDS test_clean_keep_repos
+    COMMAND ${TEST_KILL_SERVER_COMMAND}
+    COMMAND ${TEST_CLEAR_STATE_COMMAND}
     COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/repositories
 )


### PR DESCRIPTION
CMake is a generator which can be used with other tools than just `make` -- `ninja` is a good candidate which tends to build a little faster. It's therefore a bug to try invoking `make` on some target directly.

See-also: https://github.com/sysrepo/sysrepo/pull/2647
Fixes: e70b9c9 tests UPDATE cleanup SHM files after tests