### PR TITLE
Added get-data operational test filter

### DIFF
--- a/tests/np_test.h
+++ b/tests/np_test.h
@@ -122,6 +122,17 @@
     assert_string_equal(LYD_NAME(lyd_child(state->op)), "data"); \
     assert_int_equal(LY_SUCCESS, lyd_print_mem(&state->str, state->op, LYD_XML, 0));
 
+#define GET_DATA_FILTER(state, ds, filter, config_filter, origin_filter, origin_filter_count, neg_origin_filter, max_depth, with_origin, wd_mode) \
+    state->rpc = nc_rpc_getdata(ds, filter, config_filter, origin_filter, origin_filter_count, neg_origin_filter, max_depth, with_origin, wd_mode, NC_PARAMTYPE_CONST); \
+    state->msgtype = nc_send_rpc(state->nc_sess, state->rpc, 1000, &state->msgid); \
+    assert_int_equal(NC_MSG_RPC, state->msgtype); \
+    state->msgtype = nc_recv_reply(state->nc_sess, state->rpc, state->msgid, 2000, &state->envp, &state->op); \
+    assert_int_equal(state->msgtype, NC_MSG_REPLY); \
+    assert_non_null(state->op); \
+    assert_non_null(state->envp); \
+    assert_string_equal(LYD_NAME(lyd_child(state->op)), "data"); \
+    assert_int_equal(LY_SUCCESS, lyd_print_mem(&state->str, state->op, LYD_XML, 0));
+
 #define SEND_EDIT_RPC_DS(state, ds, config) \
     state->rpc = nc_rpc_edit(ds, NC_RPC_EDIT_DFLTOP_MERGE, NC_RPC_EDIT_TESTOPT_SET, NC_RPC_EDIT_ERROPT_ROLLBACK, \
             config, NC_PARAMTYPE_CONST); \

--- a/tests/test_filter.c
+++ b/tests/test_filter.c
@@ -869,6 +869,46 @@ test_get_operational_data(void **state)
     FREE_TEST_VARS(st);
 }
 
+static void
+test_getdata_operational_data(void **state)
+{
+    struct np_test *st = *state;
+    char *filter, *expected;
+
+    filter =
+            "<hardware xmlns=\"i1\">\n"
+            "  <component>\n"
+            "    <class>O-RAN-RADIO</class>\n"
+            "    <serial-num>1234</serial-num>\n"
+            "    <feature>\n"
+            "      <wireless>true</wireless>\n"
+            "    </feature>\n"
+            "  </component>\n"
+            "</hardware>\n";
+
+    GET_DATA_FILTER(st, "ietf-datastores:operational", filter, NULL, NULL, 0, 0, 0, 0, NC_WD_ALL);
+
+    expected =
+            "<get-data xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-nmda\">\n"
+            "  <data>\n"
+            "    <hardware xmlns=\"i1\">\n"
+            "      <component>\n"
+            "        <name>ComponentName</name>\n"
+            "        <class>O-RAN-RADIO</class>\n"
+            "        <serial-num>1234</serial-num>\n"
+            "        <feature>\n"
+            "          <wireless>true</wireless>\n"
+            "        </feature>\n"
+            "      </component>\n"
+            "    </hardware>\n"
+            "  </data>\n"
+            "</get-data>\n";
+
+    assert_string_equal(st->str, expected);
+
+    FREE_TEST_VARS(st);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -885,6 +925,7 @@ main(int argc, char **argv)
         cmocka_unit_test(test_get_containment_node),
         cmocka_unit_test(test_get_content_match_node),
         cmocka_unit_test(test_get_operational_data),
+		cmocka_unit_test(test_getdata_operational_data),
     };
 
     nc_verbosity(NC_VERB_WARNING);


### PR DESCRIPTION
This adds a `get-data` subtree filter test on the `operational` datastore.  At this point the test fails because none of the data is being returned by the `get-data` request.   Removing the values form the subtree filter will allow some data to be retrieved so I think the test is correct, just that the filtering is not working correctly.