### PR TITLE
build: format-check: invoke `make` in a portable way

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ add_test(NAME headers
 
 # format
 if (${SOURCE_FORMAT_ENABLED})
-    add_test(NAME format WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND make format-check)
+    add_test(NAME format WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND cmake --build ${CMAKE_BINARY_DIR} --target format-check)
 endif()
 
 # include dirs


### PR DESCRIPTION
I've added `uncrustify` to my build environment, and as a result the build started failing for me because it tried to invoke `make format-check`. I use the ninja generator for CMake, which means that there's no `Makefile` generated in my build directory.

Fix this by invoking the relevant target via CMake.