### PR TITLE
Added check to see if the commit timer is not null before deleting the timer

### DIFF
--- a/src/netconf_confirmed_commit.c
+++ b/src/netconf_confirmed_commit.c
@@ -461,8 +461,10 @@ cleanup:
 static void
 ncc_commit_confirmed(void)
 {
-    timer_delete(commit_ctx.timer);
-    commit_ctx.timer = 0;
+    if (commit_ctx.timer) {
+        timer_delete(commit_ctx.timer);
+        commit_ctx.timer = 0;
+    }
     clean_backup_directory();
 }
 


### PR DESCRIPTION
The timer was trying to be deleted even if there was no timer.