### PR TITLE
Fix setup error printing

### DIFF
--- a/tests/np_test.h
+++ b/tests/np_test.h
@@ -25,7 +25,7 @@
 #include <sysrepo.h>
 
 #define SETUP_FAIL_LOG \
-    printf("Setup fail in %s:%d.\n", __FILE__, __LINE__)
+    fprintf(stderr, "Setup fail in %s:%d.\n", __FILE__, __LINE__)
 
 #define FREE_TEST_VARS(state) \
     nc_rpc_free(state->rpc); \


### PR DESCRIPTION
When running tests via ctest, setup failure messages are not shown for
some reason (they are shown when running the test directly). Fix this by
changing the macro to print to stderr.
