### PR TITLE
Fix Systemd Unit file netopeer2-server.service

### DIFF
--- a/service/netopeer2-server.service.in
+++ b/service/netopeer2-server.service.in
@@ -4,7 +4,7 @@ Description=netopeer2 NETCONF server
 
 [Service]
 Type=notify
-ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/netopeer2-server -d -v2
+ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/netopeer2-server -d -v2 -U
 Restart=always
 SystemCallArchitectures=native
 KillMode=control-group


### PR DESCRIPTION
The netopeer2-server binary is in /usr/sbin instead of /usr/bin
since the following commit 2411516.
Moreover, a "-U" parameter is added to be able to communicate
with the service via Unix socket.

This fixes issue #1231.