### PR TITLE
build: `pthread_rwlock_t` is not available without feature macros

### DIFF
--- a/src/netconf_monitoring.c
+++ b/src/netconf_monitoring.c
@@ -14,6 +14,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
+#define _GNU_SOURCE
 #include "netconf_monitoring.h"
 
 #include <pthread.h>


### PR DESCRIPTION
When building `src/netconf_monitoring.c` with all the custom pthread functionality disabled via CMake options (i.e., orcing the usage of the compat library), the build fails with the following error:
```
Netopeer2/compat/compat.h:149:32: error: unknown type name 'pthread_rwlock_t'
```
I was getting the same error on my NixOS with clang 15.0.7, but also on an older Fedora with clang 12.

This exact same header file is included from a variety of other places, and <pthread.h> (which is where these symbols live) is included as well. It turns out that the `pthread_rwlock_t` was added in Issue 5 of POSIX, and when using the C99 standard along with no feature test macros to pick a specific version of POSIX functions, these might not be visible. Indeed this place does not define `_GNU_SOURCE` (which brings in a lot of stuff, including a new enough POSIX).

Solve this by using `_GNU_SOURCE` also from this file.

Fixes: 7e5349b compat UPDATE use latest compat lib
Fixes: 28138d5 build UPDATE use c99 standard instead of gnu99