### PR TITLE
add commandline option to set PAM Module Name/DIR used for interactive ssh authentication

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -49,7 +49,7 @@
 #include "log.h"
 #include "netconf_monitoring.h"
 
-struct np2srv np2srv = {.unix_mode = -1, .unix_uid = -1, .unix_gid = -1};
+struct np2srv np2srv = {.unix_mode = -1, .unix_uid = -1, .unix_gid = -1, .pam_config_name = NULL, .pam_config_dir = NULL};
 
 int
 np_ignore_rpc(sr_session_ctx_t *ev_sess, sr_event_t event, int *rc)

--- a/src/common.h
+++ b/src/common.h
@@ -63,6 +63,8 @@ struct np2srv {
     gid_t unix_gid;                 /**< UNIX socket GID */
     uint32_t sr_timeout;            /**< timeout in ms for all sysrepo functions */
     const char *ext_data_path;      /**< path to the data file with data for LY ext data callback */
+    const char *pam_config_name;    /**< name of the PAM config file */
+    const char *pam_config_dir;     /**< path to the PAM config dir */
 
     const char *server_dir;         /**< path to server files (just confirmed commit for the moment) */
 

--- a/src/main.c
+++ b/src/main.c
@@ -604,6 +604,11 @@ server_init(void)
     /* set libnetconf2 SSH callbacks */
     nc_server_ssh_set_hostkey_clb(np2srv_hostkey_cb, NULL, NULL);
     nc_server_ssh_set_pubkey_auth_clb(np2srv_pubkey_auth_cb, NULL, NULL);
+
+    /* configure netconf2 PAM module */
+    if (np2srv.pam_config_name) {
+        nc_server_ssh_set_pam_conf_path(np2srv.pam_config_name, np2srv.pam_config_dir);
+    }
 #endif
 
 #ifdef NC_ENABLED_TLS
@@ -1084,6 +1089,8 @@ print_usage(char *progname)
     fprintf(stdout, " -m MODE    Set mode for the listening UNIX socket.\n");
     fprintf(stdout, " -u UID     Set UID/user for the listening UNIX socket.\n");
     fprintf(stdout, " -g GID     Set GID/group for the listening UNIX socket.\n");
+    fprintf(stdout, " -n NAME    Set PAM Module config name for interactive ssh authentication.\n");
+    fprintf(stdout, " -i PATH    Set PAM Module config dir for interactive ssh authentication.\n");
     fprintf(stdout, " -t TIMEOUT Timeout in seconds of all sysrepo functions (applying edit-config, reading data, ...),\n");
     fprintf(stdout, "            if 0 (default), the default sysrepo timeouts are used.\n");
     fprintf(stdout, " -x PATH    Path to a data file with data for libyang ext data callback. They are required for\n");
@@ -1145,7 +1152,7 @@ main(int argc, char *argv[])
     np2srv.server_dir = SERVER_DIR;
 
     /* process command line options */
-    while ((c = getopt(argc, argv, "dhVp:f:U::m:u:g:t:x:v:c:")) != -1) {
+    while ((c = getopt(argc, argv, "dhVp:f:U::m:u:g:n:i:t:x:v:c:")) != -1) {
         switch (c) {
         case 'd':
             daemonize = 0;
@@ -1223,6 +1230,12 @@ main(int argc, char *argv[])
                 }
                 np2srv.unix_gid = grp->gr_gid;
             }
+            break;
+        case 'n':
+            np2srv.pam_config_name = optarg;
+            break;
+        case 'i':
+            np2srv.pam_config_dir = optarg;
             break;
         case 't':
             np2srv.sr_timeout = strtoul(optarg, &ptr, 10);


### PR DESCRIPTION
Hi,
@roytak implemented pam usage for the netconf2 lib. (https://github.com/CESNET/libnetconf2/pull/382).
But it seems there is no way to use it without patching the source of either netconf2 or dependent tools like netopeer2.

So I add the command line option for the netopeer2 server to make it usable without add the name/dir to the sources. 