### PR TITLE
ncc BUGFIX Clean backup dir properly after successful commit

### DIFF
--- a/src/netconf_confirmed_commit.c
+++ b/src/netconf_confirmed_commit.c
@@ -345,8 +345,11 @@ ncc_clean_backup_directory(void)
         goto cleanup;
     }
     while ((dirent = readdir(dir))) {
-        if (!strcmp(dirent->d_name, ".") || !strcmp(dirent->d_name, "..") ||
-                !strstr(".json", dirent->d_name) || strcmp(META_FILE, dirent->d_name)) {
+        if (!strcmp(dirent->d_name, ".") || !strcmp(dirent->d_name, "..")) {
+            continue;
+        }
+        
+        if (!strstr(dirent->d_name, ".json") && strcmp(META_FILE, dirent->d_name)) {
             /* If some unexpected file, just skip */
             continue;
         }


### PR DESCRIPTION
Hi!

My expectation is that after the confirming commit is issued, backup files (a bunch of jsons and meta file in `/var/netopeer2/confirmed_commit/`) should be cleaned. I observe they are kept and after the server restarts it rollbacks the changes even the confirming commit was successful. 

I made a fix according to my understanding, please check.