### PR TITLE
Add support for running netopeer2-server in foreground with syslog

### DIFF
--- a/doc/netopeer2-server.8
+++ b/doc/netopeer2-server.8
@@ -2,13 +2,13 @@
 .\" groff -man -Tascii netopeer2-server.8
 .\"
 
-.TH "netopeer2-server" 8 "2021-11-10" "Netopeer"
+.TH "netopeer2-server" 8 "2023-05-25" "Netopeer"
 .SH NAME
 netopeer2-server \- NETCONF server daemon build on libnetconf2 with sysrepo datastore
 .
 .SH SYNOPSIS
 .B netopeer2-server
-[\fB-dhV\fP] [\fB-p\fP \fIPATH\fP] [\fB-U\fP[\fIPATH\fP]] [\fB-m\fP \fIMODE\fP] [\fB-u\fP \fIUID\fP]
+[\fB-dFhV\fP] [\fB-p\fP \fIPATH\fP] [\fB-U\fP[\fIPATH\fP]] [\fB-m\fP \fIMODE\fP] [\fB-u\fP \fIUID\fP]
 [\fB-g\fP \fIGID\fP] [\fB-t\fP \fITIMEOUT\fP] [\fB-v\fP \fILEVEL\fP] [\fB-c\fP \fICATEGORY\fP]
 .br
 .
@@ -21,6 +21,9 @@ YANG module data in sysrepo.
 .TP
 .BR "\-d"
 Debug mode (do not daemonize and print verbose messages to stderr instead of syslog).
+.TP
+.BR "\-F"
+Run in foreground (do not daemonize) and log to syslog.
 .TP
 .BR "\-h"
 Display help.

--- a/src/main.c
+++ b/src/main.c
@@ -1078,9 +1078,10 @@ print_version(void)
 static void
 print_usage(char *progname)
 {
-    fprintf(stdout, "Usage: %s [-dhV] [-p PATH] [-U[PATH]] [-m MODE] [-u UID] [-g GID] [-t TIMEOUT] [-x PATH]\n", progname);
+    fprintf(stdout, "Usage: %s [-dFhV] [-p PATH] [-U[PATH]] [-m MODE] [-u UID] [-g GID] [-t TIMEOUT] [-x PATH]\n", progname);
     fprintf(stdout, "          [-v LEVEL] [-c CATEGORY]\n");
     fprintf(stdout, " -d         Debug mode (do not daemonize and print verbose messages to stderr instead of syslog).\n");
+    fprintf(stdout, " -F         Run in foreground, like -d, but log to syslog.\n");
     fprintf(stdout, " -h         Display help.\n");
     fprintf(stdout, " -V         Show program version.\n");
     fprintf(stdout, " -p PATH    Path to pidfile (default path is \"%s\").\n", NP2SRV_PID_FILE_PATH);
@@ -1152,10 +1153,14 @@ main(int argc, char *argv[])
     np2srv.server_dir = SERVER_DIR;
 
     /* process command line options */
-    while ((c = getopt(argc, argv, "dhVp:f:U::m:u:g:n:i:t:x:v:c:")) != -1) {
+    while ((c = getopt(argc, argv, "dFhVp:f:U::m:u:g:n:i:t:x:v:c:")) != -1) {
         switch (c) {
         case 'd':
             daemonize = 0;
+            break;
+        case 'F':
+            daemonize = 0;
+            np2_stderr_log = 0;
             break;
         case 'h':
             print_usage(argv[0]);


### PR DESCRIPTION
This patch adds support for running `netopeer2-server` under init systems like [Finit](https://github.com/troglobit/finit/), which supervise processes running in the foreground.  Similar to `-d`, but still using syslog.