### PR TITLE
tests: `SIGEV_THREAD` doesn't work under TSAN

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,8 +37,14 @@ set(test_sources "np_test.c")
 
 # list of all the tests
 set(tests test_rpc test_edit test_filter test_subscribe_filter test_subscribe_param test_parallel_sessions
-    test_candidate test_with_defaults test_nacm test_sub_ntf test_sub_ntf_advanced test_sub_ntf_filter test_yang_push
-    test_yang_push_advanced test_confirmed_commit test_error)
+    test_candidate test_with_defaults test_nacm test_sub_ntf test_sub_ntf_advanced test_sub_ntf_filter test_error)
+
+if(CMAKE_C_FLAGS MATCHES "-fsanitize=thread")
+    message(WARNING "Features which use SIGEV_THREAD are known to be broken under TSAN, disabling tests for YANG-push and confirmed commit")
+else()
+    # On TSAN, SIGEV_THREAD is known to not work: https://github.com/google/sanitizers/issues/1612
+    list(APPEND tests test_yang_push test_yang_push_advanced test_confirmed_commit)
+endif()
 
 # append url if supported
 if(NP2SRV_URL_CAPAB)


### PR DESCRIPTION
As per the docs, the SIGEV_THREAD sigevent option instructs the kernel to create a thread in this process when that timer expires (in fact this is done by the C library, and the kernel "just" wakes up that thread AFAICT). However, this newly created thread appears to have completely bypassed TSAN, and when the just-created thread hits any TSAN interceptor which assumes that some per-thread TSAN structures have been already set up, the application segfaults (for example like this):
```
 #0  0x00005555556192d4 in __tsan::user_alloc_internal(__tsan::ThreadState*, unsigned long, unsigned long, unsigned long, bool) ()
 #1  0x00005555556196a4 in __tsan::user_alloc(__tsan::ThreadState*, unsigned long, unsigned long) ()
 #2  0x00005555555d3db5 in malloc ()
 #3  0x00007ffff7889470 in timer_helper_thread (arg=<optimized out>) at ../sysdeps/unix/sysv/linux/timer_routines.c:88
 #4  0x00007ffff787ddd4 in start_thread (arg=<optimized out>) at pthread_create.c:444
 #5  0x00007ffff78ff9b0 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```
That's with the latest clang, or, in another case, with GCC:
```
 #0  0x00007ffff4e88fc6 in __sanitizer::CombinedAllocator<__sanitizer::SizeClassAllocator64<__tsan::AP64>, __sanitizer::LargeMmapAllocatorPtrArrayDynamic>::Allocate(__sanitizer::SizeClassAllocator64LocalCache<__sanitizer::SizeClassAllocator64<__tsan::AP64> >*, unsigned long, unsigned long) () from /nix/store/ds46sf6mb9xydn0gy97131y1w5hag5s8-gcc-12.2.0-lib/lib/libtsan.so.2
 #1  0x00007ffff4e8686a in __tsan::user_alloc_internal(__tsan::ThreadState*, unsigned long, unsigned long, unsigned long, bool) ()
    from /nix/store/ds46sf6mb9xydn0gy97131y1w5hag5s8-gcc-12.2.0-lib/lib/libtsan.so.2
 #2  0x00007ffff4e869d8 in __tsan::user_alloc(__tsan::ThreadState*, unsigned long, unsigned long) () from /nix/store/ds46sf6mb9xydn0gy97131y1w5hag5s8-gcc-12.2.0-lib/lib/libtsan.so.2
 #3  0x00007ffff4e4331e in malloc () from /nix/store/ds46sf6mb9xydn0gy97131y1w5hag5s8-gcc-12.2.0-lib/lib/libtsan.so.2
 #4  0x00007ffff4cab4c0 in timer_helper_thread (arg=<optimized out>) at ../sysdeps/unix/sysv/linux/timer_routines.c:88
 #5  0x00007ffff4c9fe24 in start_thread (arg=<optimized out>) at pthread_create.c:444
 #6  0x00007ffff4d219b0 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```
I have no clue on how to fix this properly within TSAN.

Bug: https://github.com/google/sanitizers/issues/1612