### PR TITLE
Configured subscription integration

### DIFF
--- a/modules/ietf-subscribed-notif-receivers.yang
+++ b/modules/ietf-subscribed-notif-receivers.yang
@@ -1,0 +1,111 @@
+module ietf-subscribed-notif-receivers {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers";
+  prefix "snr";
+
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+
+  organization
+    "IETF NETCONF Working Group";
+
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/netconf>
+     WG List:  <netconf@ietf.org>
+
+     Authors: Mahesh Jethanandani (mjethanandani at gmail dot com)
+              Kent Watsen (kent plus ietf at watsen dot net)";
+
+  description
+    "This YANG module is implemented by Publishers implementing
+     the 'ietf-subscribed-notifications' module defined in RFC 8639.
+
+     While this module is defined in RFC XXXX, which primarily
+     defines an HTTPS-based transport for notifications, this module
+     is not HTTP-specific.  It is a generic extension that can be
+     used by any 'notif' transport.
+
+     This module defines two 'augment' statements.  One statement
+     augments a 'container' statement called 'receiver-instances'
+     into the top-level 'subscriptions' container.  The other
+     statement, called 'receiver-instance-ref', augments a 'leaf'
+     statement into each 'receiver' that references one of the
+     afore mentioned receiver instances.  This indirection enables
+     multiple configured subscriptions to send notifications to
+     the same receiver instance.
+
+     Copyright (c) 2022 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Revised BSD
+     License set forth in Section 4.c of the IETF Trust's Legal
+     Provisions Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX; see
+     the RFC itself for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision "2022-11-03" {
+    description
+      "Initial Version.";
+    reference
+      "RFC XXXX: An HTTPS-based Transport for YANG Notifications.";
+  }
+
+  augment "/sn:subscriptions" {
+    container receiver-instances {
+      description
+        "A container for all instances of receivers.";
+
+      list receiver-instance {
+        key "name";
+
+        leaf name {
+          type string;
+          description
+            "An arbitrary but unique name for this receiver
+             instance.";
+        }
+
+        choice transport-type {
+          mandatory true;
+          description
+            "Choice of different types of transports used to
+             send notifications.  The 'case' statements must
+             be augmented in by other modules.";
+        }
+        description
+          "A list of all receiver instances.";
+      }
+    }
+    description
+      "Augment the subscriptions container to define the
+       transport type.";
+  }
+
+  augment
+    "/sn:subscriptions/sn:subscription/sn:receivers/sn:receiver" {
+    leaf receiver-instance-ref {
+      type leafref {
+        path "/sn:subscriptions/snr:receiver-instances/" +
+             "snr:receiver-instance/snr:name";
+      }
+      description
+        "Reference to a receiver instance.";
+    }
+    description
+      "Augment the subscriptions container to define an optional
+       reference to a receiver instance.";
+  }
+}

--- a/modules/ietf-udp-client.yang
+++ b/modules/ietf-udp-client.yang
@@ -8,11 +8,11 @@ module ietf-udp-client {
     reference
       "RFC 6991: Common YANG Data Types";
   }
-  import ietf-tls-client {
+  /*import ietf-tls-client {
     prefix tlsc;
     reference
       "RFC TTTT: YANG Groupings for TLS Clients and TLS Servers";
-  }
+  }*/
 
   organization "IETF NETCONF (Network Configuration) Working Group";
   contact
@@ -82,7 +82,7 @@ module ietf-udp-client {
         "Port number of the UDP client.";
     }
 
-    container dtls {
+    /*container dtls {
       if-feature dtls13;
       presence dtls;
       uses tlsc:tls-client-grouping {
@@ -99,6 +99,6 @@ module ietf-udp-client {
       }
       description 
         "Container for configuring DTLS 1.3 parameters.";
-    }
+    }*/
   }
 }

--- a/modules/ietf-udp-client.yang
+++ b/modules/ietf-udp-client.yang
@@ -1,0 +1,104 @@
+module ietf-udp-client {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-udp-client";
+  prefix udpc;
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-tls-client {
+    prefix tlsc;
+    reference
+      "RFC TTTT: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  organization "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <http:/tools.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Authors:  Alex Huang Feng
+               <mailto:alex.huang-feng@insa-lyon.fr>
+               Pierre Francois
+               <mailto:pierre.francois@insa-lyon.fr>
+               Guangying Zheng
+               <mailto:zhengguangying@huawei.com>
+               Tianran Zhou
+               <mailto:zhoutianran@huawei.com>
+               Thomas Graf
+               <mailto:thomas.graf@swisscom.com>
+               Paolo Lucente
+               <mailto:paolo@ntt.net>";
+
+  description
+    "Defines a generic grouping for UDP-based client applications.
+
+    Copyright (c) 2023 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Revised BSD License set forth in Section
+    4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+    (https://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC-to-be; see the RFC
+    itself for full legal notices.";
+
+  revision 2023-05-08 {
+    description
+      "Initial revision";
+    reference
+      "RFC-to-be: UDP-based Transport for Configured Subscriptions";
+  }
+
+ /*
+  * FEATURES
+  */
+  feature dtls13 {
+    description
+      "This feature indicates that DTLS 1.3 encryption of UDP
+       packets is supported.";
+  }
+
+  grouping udp-client-grouping {
+    description
+      "Provides a reusable grouping for configuring a UDP client.";
+
+    leaf remote-address {
+      type inet:ip-address-no-zone;
+      mandatory true;
+      description
+        "IP address of the UDP client, which can be an
+        IPv4 address or an IPV6 address.";
+    }
+
+    leaf remote-port {
+      type inet:port-number;
+      mandatory true;
+      description
+        "Port number of the UDP client.";
+    }
+
+    container dtls {
+      if-feature dtls13;
+      presence dtls;
+      uses tlsc:tls-client-grouping {
+        // Using tls-client-grouping without TLS1.2 parameters
+        // allowing only DTLS 1.3
+        refine "client-identity/auth-type/tls12-psk" {
+          // create the logical impossibility of enabling TLS1.2
+          if-feature "not tlsc:client-ident-tls12-psk";
+        }
+        refine "server-authentication/tls12-psks" {
+          // create the logical impossibility of enabling TLS1.2
+          if-feature "not tlsc:server-auth-tls12-psk";
+        }
+      }
+      description 
+        "Container for configuring DTLS 1.3 parameters.";
+    }
+  }
+}

--- a/modules/ietf-udp-notif-transport.yang
+++ b/modules/ietf-udp-notif-transport.yang
@@ -1,0 +1,136 @@
+module ietf-udp-notif-transport {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-udp-notif-transport";
+  prefix unt;
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+  import ietf-subscribed-notif-receivers {
+    prefix snr;
+    reference
+      "RFC YYYY: An HTTPS-based Transport for
+                 Configured Subscriptions";
+  }
+  import ietf-udp-client {
+    prefix udpc;
+    reference
+      "RFC-to-be: UDP-based Transport for Configured Subscriptions";
+  }
+
+  organization "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <http:/tools.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Authors:  Guangying Zheng
+               <mailto:zhengguangying@huawei.com>
+               Tianran Zhou
+               <mailto:zhoutianran@huawei.com>
+               Thomas Graf
+               <mailto:thomas.graf@swisscom.com>
+               Pierre Francois
+               <mailto:pierre.francois@insa-lyon.fr>
+               Alex Huang Feng
+               <mailto:alex.huang-feng@insa-lyon.fr>
+               Paolo Lucente
+               <mailto:paolo@ntt.net>";
+
+  description
+    "Defines UDP-Notif as a supported transport for subscribed
+    event notifications.
+
+    Copyright (c) 2023 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Revised BSD License set forth in Section
+    4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+    (https://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC-to-be; see the RFC
+    itself for full legal notices.";
+
+  revision 2023-05-08 {
+    description
+      "Initial revision";
+    reference
+      "RFC-to-be: UDP-based Transport for Configured Subscriptions";
+  }
+ 
+ /*
+  * FEATURES
+  */
+  feature encode-cbor {
+    description
+      "This feature indicates that CBOR encoding of notification
+       messages is supported.";
+  }
+  feature segmentation {
+    description
+      "This feature indicates segmentation of notification messages 
+      is supported.";
+  }
+
+ /*
+  * IDENTITIES
+  */  
+  identity udp-notif {
+    base sn:transport;
+    description
+      "UDP-Notif is used as transport for notification messages
+        and state change notifications.";
+  }
+
+  identity encode-cbor {
+    base sn:encoding;
+    description
+      "Encode data using CBOR as described in RFC 9254.";
+    reference
+      "RFC 9254: CBOR Encoding of Data Modeled with YANG";
+  }
+
+  grouping udp-notif-receiver-grouping {
+    description
+      "Provides a reusable description of a UDP-Notif target
+      receiver.";
+
+    uses udpc:udp-client-grouping;
+
+    leaf enable-segmentation {
+      if-feature segmentation;
+      type boolean;
+      default false;
+      description 
+        "The switch for the segmentation feature. When disabled, the
+        publisher will not allow fragment for a very large data";
+    }
+
+    leaf max-segment-size {
+      when "../enable-segmentation = 'true'";
+      if-feature segmentation;
+      type uint32;
+      description 
+        "UDP-Notif provides a configurable max-segment-size to
+        control the size of each segment (UDP-Notif header, with
+        options, included).";
+    }
+  }
+
+  augment "/sn:subscriptions/snr:receiver-instances/" +
+          "snr:receiver-instance/snr:transport-type" {
+    case udp-notif {
+      container udp-notif-receiver {
+        description
+          "The UDP-notif receiver to send notifications to.";
+        uses udp-notif-receiver-grouping;
+      }
+    }
+    description
+      "Augment the transport-type choice to include the 'udp-notif'
+       transport.";
+  }
+}

--- a/modules/ietf-udp-notif.yang
+++ b/modules/ietf-udp-notif.yang
@@ -157,12 +157,12 @@ module ietf-udp-notif {
     }*/
   }
 
-  augment "/sn:subscriptions/sn:subscription/sn:receivers/sn:receiver" {
+  /*augment "/sn:subscriptions/sn:subscription/sn:receivers/sn:receiver" {
     when "derived-from(../../transport, 'un:udp-notif')";
     description
       "This augmentation allows UDP-Notif specific parameters to be
        exposed for a subscription.";
 
     uses udp-receiver-grouping;
-  }
+  }*/
 }

--- a/modules/ietf-udp-notif.yang
+++ b/modules/ietf-udp-notif.yang
@@ -13,11 +13,11 @@ module ietf-udp-notif {
     reference
       "RFC 6991: Common YANG Data Types";
   }
-  import ietf-tls-client {
+  /*import ietf-tls-client {
     prefix tlsc;
     reference
       "RFC YYYY: YANG Groupings for TLS Clients and TLS Servers";
-  }
+  }*/
 
   organization "IETF NETCONF (Network Configuration) Working Group";
   contact
@@ -137,7 +137,7 @@ module ietf-udp-notif {
         options, included).";
     }
 
-    container dtls {
+    /*container dtls {
       if-feature dtls-supported;
       presence dtls;
       uses tlsc:tls-client-grouping {
@@ -154,7 +154,7 @@ module ietf-udp-notif {
       }
       description 
         "Container for configuring DTLS 1.3 parameters if DTLS is enabled.";
-    }
+    }*/
   }
 
   augment "/sn:subscriptions/sn:subscription/sn:receivers/sn:receiver" {

--- a/modules/ietf-udp-notif.yang
+++ b/modules/ietf-udp-notif.yang
@@ -1,0 +1,168 @@
+module ietf-udp-notif {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-udp-notif";
+  prefix un;
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-tls-client {
+    prefix tlsc;
+    reference
+      "RFC YYYY: YANG Groupings for TLS Clients and TLS Servers";
+  }
+
+  organization "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <http:/tools.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Authors:  Guangying Zheng
+               <mailto:zhengguangying@huawei.com>
+               Tianran Zhou
+               <mailto:zhoutianran@huawei.com>
+               Thomas Graf
+               <mailto:thomas.graf@swisscom.com>
+               Pierre Francois
+               <mailto:pierre.francois@insa-lyon.fr>
+               Alex Huang Feng
+               <mailto:alex.huang-feng@insa-lyon.fr>
+               Paolo Lucente
+               <mailto:paolo@ntt.net>";
+
+  description
+    "Defines UDP-Notif as a supported transport for subscribed
+    event notifications.
+
+    Copyright (c) 2022 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Revised BSD License set forth in Section
+    4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+    (https://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC XXXX; see the RFC
+    itself for full legal notices.";
+
+  revision 2022-08-29 {
+    description
+      "Removed enable-dtls leaf and changed container dtls to presence container.
+      Removed TLS1.2 references from tls-client-grouping";
+    reference
+      "RFC XXXX: UDP-based Transport for Configured Subscriptions";
+  }
+ 
+ /*
+  * FEATURES
+  */
+  feature encode-cbor {
+    description
+      "This feature indicates that CBOR encoding of notification
+       messages is supported.";
+  }
+  feature dtls-supported {
+    description
+      "This feature indicates that DTLS encryption of notification
+       messages is supported.";
+  }
+  feature segmentation {
+    description
+      "This feature indicates segmentation of notification messages 
+      is supported.";
+  }
+
+ /*
+  * IDENTITIES
+  */  
+  identity udp-notif {
+    base sn:transport;
+    description
+      "UDP-Notif is used as transport for notification messages
+        and state change notifications.";
+  }
+
+  identity encode-cbor {
+    base sn:encoding;
+    description
+      "Encode data using CBOR as described in RFC 9254.";
+    reference
+      "RFC 9254: CBOR Encoding of Data Modeled with YANG";
+  }
+
+  grouping udp-receiver-grouping {
+    description
+      "Provides a reusable description of a UDP-Notif target
+      receiver.";
+
+    leaf address {
+      type inet:ip-address;
+      mandatory true;
+      description
+        "IP address of target UDP-Notif receiver, which can be an
+        IPv4 address or an IPV6 address.";
+    }
+  
+    leaf port {
+      type inet:port-number;
+      mandatory true;
+      description
+        "Port number of target UDP-Notif receiver.";
+    }
+
+    leaf enable-segmentation {
+      if-feature segmentation;
+      type boolean;
+      default false;
+      description 
+        "The switch for the segmentation feature. When disabled, the
+        publisher will not allow fragment for a very large data";
+    }
+
+    leaf max-segment-size {
+      when "../enable-segmentation = 'true'";
+      if-feature segmentation;
+      type uint32;
+      description 
+        "UDP-Notif provides a configurable max-segment-size to
+        control the size of each segment (UDP-Notif header, with
+        options, included).";
+    }
+
+    container dtls {
+      if-feature dtls-supported;
+      presence dtls;
+      uses tlsc:tls-client-grouping {
+        // Using tls-client-grouping without TLS1.2 parameters
+        // allowing only DTLS 1.3
+        refine "client-identity/auth-type/tls12-psk" {
+          // create the logical impossibility of enabling TLS1.2
+          if-feature "not tlsc:client-ident-tls12-psk";
+        }
+        refine "server-authentication/tls12-psks" {
+          // create the logical impossibility of enabling TLS1.2
+          if-feature "not tlsc:server-auth-tls12-psk";
+        }
+      }
+      description 
+        "Container for configuring DTLS 1.3 parameters if DTLS is enabled.";
+    }
+  }
+
+  augment "/sn:subscriptions/sn:subscription/sn:receivers/sn:receiver" {
+    when "derived-from(../../transport, 'un:udp-notif')";
+    description
+      "This augmentation allows UDP-Notif specific parameters to be
+       exposed for a subscription.";
+
+    uses udp-receiver-grouping;
+  }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -38,7 +38,7 @@ MODULES=(
 "ietf-interfaces@2018-02-20.yang"
 "ietf-ip@2018-02-22.yang"
 "ietf-network-instance@2019-01-21.yang"
-"ietf-subscribed-notifications@2019-09-09.yang -e encode-xml -e replay -e subtree -e xpath"
+"ietf-subscribed-notifications@2019-09-09.yang -e encode-xml -e replay -e subtree -e xpath -e configured"
 "ietf-yang-push@2019-09-09.yang -e on-change"
 )
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -40,6 +40,10 @@ MODULES=(
 "ietf-network-instance@2019-01-21.yang"
 "ietf-subscribed-notifications@2019-09-09.yang -e encode-xml -e replay -e subtree -e xpath -e configured"
 "ietf-yang-push@2019-09-09.yang -e on-change"
+"ietf-subscribed-notif-receivers.yang"
+"ietf-udp-client.yang"
+"ietf-udp-notif.yang"
+"ietf-udp-notif-transport.yang"
 )
 
 CMD_INSTALL=


### PR DESCRIPTION
Hello,
This is the first part of the configured subscription integration.
Enable the configured feature in setup.sh.
Add the new yang files to setup.sh.
Add the yang files to the project with TLS disabled.
Direct definition of the receiver in the subscription is disabled. Only reference receiver instances is enabled.
This avoids this warning:

root@ubuntu2204:~/sshfs_root# netopeer2-cli 
> connect -u
ly WARNING: Schema node "transport" for parent "/ietf-subscribed-notifications:subscriptions/subscription" not found; in expr "derived-from(../../transport" with context node "/ietf-subscribed-notifications:subscriptions/subscription/receivers/receiver".
