### PR TITLE
cmake: don't hard-code absolute path name /etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,10 +347,7 @@ if(NP2SRV_HAVE_SYSTEMD)
     install(FILES ${PROJECT_BINARY_DIR}/netopeer2-server.service DESTINATION ${SYSTEMD_UNIT_DIR})
 endif()
 
-# copy pam service to /etc/pam.d
-if(EXISTS "/etc/pam.d")
-    install(FILES "${CMAKE_SOURCE_DIR}/pam/netopeer2.conf" DESTINATION "/etc/pam.d")
-endif()
+install(FILES "${CMAKE_SOURCE_DIR}/pam/netopeer2.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/pam.d")
 
 if(SYSREPO_SETUP)
     install(CODE "


### PR DESCRIPTION
cmake: don't hard-code absolute path name `/etc`

- this breaks packaging and installation into a prefix in general
- there's a [`GNUInstallDirs` variable for `/etc`](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html), too

Also, don't make this installation conditional on the existence of `/etc`. Whether or not that directory exists on a build system has no meaning for installation to a target system. This had a potential to break cross-compiling.