### PR TITLE
tests: shorten path to the UNIX socket

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ get_filename_component(ROOT_DIR "${CMAKE_SOURCE_DIR}" REALPATH)
 
 # test directories that can be adjusted
 if(NOT NP2_TEST_ROOT_DIR)
-    set(NP2_TEST_ROOT_DIR ${CMAKE_CURRENT_BINARY_DIR}/repositories)
+    set(NP2_TEST_ROOT_DIR ${PROJECT_BINARY_DIR}/repos)
 endif()
 if(NOT NP2_TEST_MODULE_DIR)
     set(NP2_TEST_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/modules)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,7 +102,7 @@ if(ENABLE_TESTS)
     add_custom_target(test_clean
         COMMAND ${TEST_KILL_SERVER_COMMAND}
         COMMAND ${TEST_CLEAR_STATE_COMMAND}
-        COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/repositories
+        COMMAND rm -rf ${NP2_TEST_ROOT_DIR}
     )
 endif()
 

--- a/tests/np2_test_config.h.in
+++ b/tests/np2_test_config.h.in
@@ -35,7 +35,7 @@
 #define NP_PID_FILE "np2.pid"
 
 /* server socket path */
-#define NP_SOCKET_FILE "np2.sock"
+#define NP_SOCKET_FILE "s"
 
 /* server ext data file */
 #define NP_EXT_DATA_FILE "schema_mount.xml"

--- a/tests/scripts/kill_np_server.sh.in
+++ b/tests/scripts/kill_np_server.sh.in
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-NP2_TESTS_BINARY_DIR="@CMAKE_CURRENT_BINARY_DIR@"
-[ -z "$NP2_TESTS_BINARY_DIR" ] &&
+NP2_TEST_ROOT_DIR="@NP2_TEST_ROOT_DIR@"
+[ -z "$NP2_TEST_ROOT_DIR" ] &&
         echo "Expected an argument with to the test directory" &&
         exit 1
 
-for pidfile in $NP2_TESTS_BINARY_DIR/repositories/*/np2.pid
+for pidfile in $NP2_TEST_ROOT_DIR/*/np2.pid
 do
         [ -f "$pidfile" ] && kill "$(cat "$pidfile")"
 done


### PR DESCRIPTION
I started getting failures because these paths are now "too long". It used to work fine as far as I can recall, so let's shave off a few bytes from these paths, and hope for the best.