### PR TITLE
Remove netopeer2-cli's CRL from a file support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -21,9 +21,10 @@ trusted store, or use the default directory. To add certificates
 to this directory, use the `cert add` command.
 
 ## Certificate Revocation Lists
-For netopeer-cli to check if a certificate was not revocated by
-its issuer, use the `crl add` command to provide
-CRLs of your trusted CAs for netopeer-cli.
+CRLs are automatically downloaded from URIs specified in the
+x509 CRLDistributionPoints extensions of set certificates.
+Be wary that if any configured certificate has this extension,
+then a CRL issued by the server's CA has to be present for the connection to succeed. 
 
 ## Certificates
 

--- a/cli/completion.c
+++ b/cli/completion.c
@@ -83,9 +83,8 @@ complete_cmd(const char *buf, const char *hint, linenoiseCompletions *lc)
 
     if (!strncmp(buf, "searchpath ", 11)
 #ifdef NC_ENABLED_SSH_TLS
-            || !strncmp(buf, "auth keys add ", 14) ||
-            !strncmp(buf, "cert add ", 9) || !strncmp(buf, "cert remove ", 12) || !strncmp(buf, "cert replaceown ", 16) ||
-            !strncmp(buf, "crl add ", 8) || !strncmp(buf, "crl remove ", 11)
+            || !strncmp(buf, "auth keys add ", 14) || !strncmp(buf, "cert add ", 9) ||
+            !strncmp(buf, "cert remove ", 12) || !strncmp(buf, "cert replaceown ", 16)
 #endif
        ) {
         linenoisePathCompletion(buf, hint, lc);

--- a/cli/configuration.c
+++ b/cli/configuration.c
@@ -45,7 +45,6 @@ struct cli_opts opts = {.output_format = LYD_XML};
 #define NCC_DIR ".netopeer2-cli"
 /* all these appended to NCC_DIR */
 #define CA_DIR "certs"
-#define CRL_DIR "crl"
 #define CERT_CRT "client.crt"
 #define CERT_PEM "client.pem"
 #define CERT_KEY "client.key"
@@ -198,50 +197,6 @@ get_default_trustedCA_dir(DIR **ret_dir)
     }
 
     return cert_dir;
-}
-
-char *
-get_default_CRL_dir(DIR **ret_dir)
-{
-    char *netconf_dir, *crl_dir;
-
-    if (!(netconf_dir = get_netconf_dir())) {
-        return NULL;
-    }
-
-    if (asprintf(&crl_dir, "%s/%s", netconf_dir, CRL_DIR) == -1) {
-        ERROR(__func__, "asprintf() failed (%s:%d).", __FILE__, __LINE__);
-        ERROR(__func__, "Unable to use the trusted CA directory due to the previous error.");
-        free(netconf_dir);
-        return NULL;
-    }
-    free(netconf_dir);
-
-    if (ret_dir) {
-        if (!(*ret_dir = opendir(crl_dir))) {
-            ERROR(__func__, "Unable to open the default CRL directory (%s).", strerror(errno));
-        }
-        free(crl_dir);
-        return NULL;
-    }
-
-    errno = 0;
-    if (eaccess(crl_dir, R_OK | W_OK | X_OK)) {
-        if (errno == ENOENT) {
-            ERROR(__func__, "Default CRL dir does not exist, creating it.");
-            if (mkdir(crl_dir, 00777)) {
-                ERROR(__func__, "Failed to create the default CRL directory (%s).", strerror(errno));
-                free(crl_dir);
-                return NULL;
-            }
-        } else {
-            ERROR(__func__, "Unable to access the default CRL directory (%s).", strerror(errno));
-            free(crl_dir);
-            return NULL;
-        }
-    }
-
-    return crl_dir;
 }
 
 void

--- a/cli/doc/netopeer2-cli.1
+++ b/cli/doc/netopeer2-cli.1
@@ -314,41 +314,6 @@ see \fIRFC 6243 section 3\fR.
 .RE
 .RE
 
-
-.SS crl
-Manage Certificate Revocation List certificates that are stored in the \fI~/.netopeer2-cli/crl\fR directory.
-.PP
-This command is available only with TLS support.
-.PP
-
-.B crl
-[\-\-help] [display] [add \fIcrl_path\fR] [remove \fIcrl_name\fR]
-.PP
-.RS 4
-
-.B display
-.RS 4
-Displays all the recognized CRLs in \fI~/.netopeer2-cli/crl\fR. First the file name, then issuer, last and next update dates are shown for each CRL followed by the serial numbers and revocation dates of all the revocated certificates.
-.RE
-.PP
-
-.B add
-\fIcrl_path\fR
-.RS 4
-Adds the \fIcrl_path\fR CRL to the \fI~/.netopeer2-cli/crl\fR dir and recalculates hashes of all the CRLs.
-.RE
-.PP
-
-.B remove
-\fIcrl_name\fR
-.RS 4
-Removes the \fIcert_name\fR CRL from the \fI~/.netopeer2-cli/crl\fR dir and recalculates hashes of all the CRLs. \fIcrl_name\fR is the CRL file name, as displayed in the
-.B crl display
-command output.
-.RE
-.RE
-
-
 .SS delete-config
 Perform NETCONF <delete-config> operation. For more details see \fIRFC 6241 section 7.4\fR.
 .PP
@@ -1416,12 +1381,6 @@ Per user private key for the user certificate. Needs a corresponding certificate
 .I ~/.netopeer2-cli/certs
 .RS
 Per user trusted Certificate Authority directory that is searched when verifying a server certificate. Only with TLS support.
-.RE
-.PP
-.I ~/.netopeer2-cli/crl
-.RS
-Per user Certificate Revocation List directory that is searched when verifying a server certificate. Only with TLS support.
-
 
 .SH SEE ALSO
 RFC 5277 (Event Notifications)


### PR DESCRIPTION
CRLs are now obtainable only through a x509 extension.

Fixes #1597 