### PR TITLE
Fix apkg rpm build

### DIFF
--- a/distro/pkg/rpm/netopeer2.spec
+++ b/distro/pkg/rpm/netopeer2.spec
@@ -63,6 +63,7 @@ a single established NETCONF session.
 
 %build
 %cmake -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
+       -DCMAKE_INSTALL_SYSCONFDIR=/etc \
        -DSYSREPO_SETUP=OFF \
        -DPIDFILE_PREFIX=/run \
        -DSERVER_DIR=%{_sharedstatedir}/netopeer2-server


### PR DESCRIPTION
On Almalinux9 (and probably other RHEL9 like systems) the "apkg build" packaging step for RPMs seems broken.

I'm not sure, what realy happen but some suggestions. 

The cmake file install/copies a file with the line
 ``` install(FILES "${CMAKE_SOURCE_DIR}/pam/netopeer2.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/pam.d")``` 
 
 `CMAKE_INSTALL_SYSCONFDIR` is set to "etc" by default, what looks to be correct.
 
 However, maybe related to [cmake GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases) and and a set/default `CMAKE_INSTALL_PREFIX` it's expanded internal to `/usr/etc`, resulting the file mentioned above is put to `.../usr/etc/pam.d/`
 
 The RPM Spec file on the other side, expect it in `%{_sysconfdir}` aka  `/etc` and fails. 
 A solution is to set `CMAKE_INSTALL_SYSCONFDIR` to the absolut path `/etc`. 
 
 Thats what this MR did. :-) 
 
 
