### PR TITLE
build: read packaging version form CMakeLists.txt

### DIFF
--- a/distro/scripts/make-archive.sh
+++ b/distro/scripts/make-archive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # create archive from current source using git
 
-VERSION=$(git log --oneline -n1 --grep="^VERSION" | rev | cut -d' ' -f1 | rev)
+VERSION=$(grep set\(NP2SRV_VERSION CMakeLists.txt | cut -d ' ' -f 2 | tr -d ')')
 
 NAMEVER=netopeer2-$VERSION
 ARCHIVE=$NAMEVER.tar.gz


### PR DESCRIPTION
Same as https://github.com/CESNET/libnetconf2/pull/555, https://github.com/sysrepo/sysrepo/pull/3676 and https://github.com/CESNET/libyang/pull/2427 for https://github.com/CESNET/libyang/issues/2423.

Builds package from CMakeLists.txt so you can clone with --depth=1.