### PR TITLE
Minor modifications to ietf-system-capabilities state RFC 9196

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -604,8 +604,15 @@ np2srv_capabilities_oper_cb(sr_session_ctx_t *session, uint32_t sub_id,
         }
 
         if (lyd_new_list(datastore_capas, NULL, "per-node-capabilities",
-                0, &per_node_capas, '/')) {
+                0, &per_node_capas, "")) {
             ERR("Failed to create per-node-capabilities.");
+            rc = -1;
+            goto cleanup;
+        }
+
+        if (lyd_new_term(per_node_capas, NULL, "node-selector", "/",
+                0, NULL)) {
+            ERR("Failed to create node-selector.");
             rc = -1;
             goto cleanup;
         }

--- a/tests/test_filter.c
+++ b/tests/test_filter.c
@@ -1445,8 +1445,7 @@ test_depth(void **state)
     GET_DATA_FILTER(st, "ietf-datastores:running", filter, NULL, NULL, 0, 0, 1, 0, NC_WD_ALL);
     expected =
             "<get-data xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-nmda\">\n"
-            "  <data>\n"
-            "  </data>\n"
+            "  <data/>\n"
             "</get-data>\n";
     assert_string_equal(st->str, expected);
     FREE_TEST_VARS(st);


### PR DESCRIPTION
Hi,

I propose those two patches to modify the content of the ietf-system-capabilities state.

For the first patch:
"/" xpath  is missing from the state.
As per-node-capabilities is a keyless list. Create the node-selector with lyd_new_term.
For the 2nd patch:
I removed the config-changes and state-changes, so another application can merge
custom xpaths with custom support for on-change and periodic notifications.

Thank you.
Best regards,
Jeremie


