### PR TITLE
support multiple subscriptions to `/ietf-subscribed-notifications:streams`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1306,7 +1306,12 @@ server_data_subscribe(void)
     }
 
     /* operational data */
-    SR_OPER_SUBSCR(mod_name, "/ietf-subscribed-notifications:streams", srsn_oper_data_streams_cb);
+    rc = sr_oper_get_subscribe(np2srv.sr_sess, mod_name, "/ietf-subscribed-notifications:streams",
+            srsn_oper_data_streams_cb, NULL, SR_SUBSCR_OPER_MERGE, &np2srv.sr_data_sub);
+    if (rc != SR_ERR_OK) {
+        ERR("Subscribing for providing \"%s\" state data failed (%s).", mod_name, sr_strerror(rc));
+        goto error;
+    }
     rc = sr_oper_get_subscribe(np2srv.sr_sess, mod_name, "/ietf-subscribed-notifications:subscriptions",
             np2srv_oper_sub_ntf_subscriptions_cb, NULL, SR_SUBSCR_OPER_MERGE, &np2srv.sr_data_sub);
     if (rc != SR_ERR_OK) {


### PR DESCRIPTION
Currently, the NETCONF server makes an assumption that it will be the only entity which manages this container. With our RESTCONF server, this is no longer the case. Unless there's a systemwide "notification daemon" which will be in charge of this, the only reasonable choice is, IMHO, to rely on the usual rules of data merging as provided by sysrepo.