### PR TITLE
Add error log on configuration update fail

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1216,7 +1216,9 @@ np2srv_libnetconf2_config_cb(sr_session_ctx_t *session, uint32_t UNUSED(sub_id),
     diff = sr_get_change_diff(session);
     rc = nc_server_config_setup_diff(diff);
     if (rc) {
-        /* return value ignored anyway */
+        /* return value ignored anyway, this is a "done" event and the change is already committed,
+         * so at least make it visible that the server configuration is now out of sync with it */
+        ERR("Failed to apply the new server configuration, it is out of sync with the datastore.");
         return rc;
     }
 


### PR DESCRIPTION
Even though libnetconf2 will most likely log something when this call fails, netopeer2 should still at least log this simple error message, because config update failing leaves it in an almost unrecoverable state.